### PR TITLE
Add title and their associated methods

### DIFF
--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -410,7 +410,7 @@ class ConfirmDeny(discord.ui.View):
         for item in self.children:
             item.disabled = True
         if self.timed_out:
-            await self.msg.edit(embed=membed("Timed out waiting for a response.\n" # type: ignore
+            await self.msg.edit(embed=membed("Timed out waiting for a response.\n" 
                                              "The operation was cancelled."), view=None)
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
@@ -420,7 +420,7 @@ class ConfirmDeny(discord.ui.View):
         else:
             emb = membed(
                 f"{self.interaction.user.mention} can only give consent to perform this action.")
-            await interaction.response.send_message(embed=emb, ephemeral=True) # type: ignore
+            await interaction.response.send_message(embed=emb, ephemeral=True) 
             return False
 
     @discord.ui.button(label='Confirm', style=discord.ButtonStyle.gray)
@@ -431,7 +431,7 @@ class ConfirmDeny(discord.ui.View):
             item.disabled = True
 
         tables_to_delete = [BANK_TABLE_NAME, INV_TABLE_NAME, COOLDOWN_TABLE_NAME, SLAY_TABLE_NAME]
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
             for table in tables_to_delete:
                 await conn.execute(f"DELETE FROM `{table}` WHERE userID = ?", (self.member.id,))
@@ -474,11 +474,11 @@ class BlackjackUi(discord.ui.View):
         await self.disable_all_items()
         if not self.finished:
 
-            namount = self.client.games[self.interaction.user.id][-1]  # type: ignore
+            namount = self.client.games[self.interaction.user.id][-1]  
             namount = floor(((130 / 100) * namount))
-            del self.client.games[self.interaction.user.id]  # type: ignore
+            del self.client.games[self.interaction.user.id]  
 
-            async with self.client.pool_connection.acquire() as conn:  # type: ignore
+            async with self.client.pool_connection.acquire() as conn:  
                 conn: asqlite_Connection
 
                 await Economy.update_bank_new(self.interaction.guild.me, conn, namount)
@@ -495,7 +495,7 @@ class BlackjackUi(discord.ui.View):
             losse.set_author(name=f"{self.interaction.user.name}'s timed-out blackjack game",
                              icon_url=self.interaction.user.display_avatar.url)
 
-            return await self.message.edit( # type: ignore
+            return await self.message.edit( 
                 content=None, embed=losse, view=self)
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
@@ -506,29 +506,29 @@ class BlackjackUi(discord.ui.View):
                 description=f"This game is being held under {self.interaction.user.name}'s name. Not yours.",
                 color=0x2F3136
             )
-            await interaction.response.send_message(embed=emb, ephemeral=True) # type: ignore
+            await interaction.response.send_message(embed=emb, ephemeral=True) 
             return False
 
     @discord.ui.button(label='Hit', style=discord.ButtonStyle.blurple)
     async def hit_bj(self, interaction: discord.Interaction, button: discord.ui.Button):
 
-        namount = self.client.games[interaction.user.id][-1] # type: ignore
-        deck = self.client.games[interaction.user.id][0]  # type: ignore
-        player_hand = self.client.games[interaction.user.id][1]  # type: ignore
+        namount = self.client.games[interaction.user.id][-1] 
+        deck = self.client.games[interaction.user.id][0]  
+        player_hand = self.client.games[interaction.user.id][1]  
 
         player_hand.append(deck.pop())
-        self.client.games[interaction.user.id][-2].append(display_user_friendly_card_format(player_hand[-1])) # type: ignore
+        self.client.games[interaction.user.id][-2].append(display_user_friendly_card_format(player_hand[-1])) 
         player_sum = sum(player_hand)
 
         if player_sum > 21:
 
             await self.disable_all_items()
             self.finished = True
-            dealer_hand = self.client.games[interaction.user.id][2] # type: ignore
-            d_fver_p = [num for num in self.client.games[interaction.user.id][-2]] # type: ignore
-            d_fver_d = [num for num in self.client.games[interaction.user.id][-3]] # type: ignore
-            del self.client.games[interaction.user.id] # type: ignore
-            async with self.client.pool_connection.acquire() as conn:  # type: ignore
+            dealer_hand = self.client.games[interaction.user.id][2] 
+            d_fver_p = [num for num in self.client.games[interaction.user.id][-2]] 
+            d_fver_d = [num for num in self.client.games[interaction.user.id][-3]] 
+            del self.client.games[interaction.user.id] 
+            async with self.client.pool_connection.acquire() as conn:  
                 conn: asqlite_Connection
 
                 await Economy.update_bank_new(interaction.user, conn, namount, "bjla")
@@ -552,20 +552,20 @@ class BlackjackUi(discord.ui.View):
 
                 embed.set_author(name=f"{interaction.user.name}'s losing blackjack game",
                                  icon_url=interaction.user.display_avatar.url)
-                await interaction.response.edit_message(content=None, embed=embed, view=None) # type: ignore
+                await interaction.response.edit_message(content=None, embed=embed, view=None) 
 
         elif sum(player_hand) == 21:
 
             self.finished = True
             await self.disable_all_items()
 
-            dealer_hand = self.client.games[interaction.user.id][2] # type: ignore
-            d_fver_p = [num for num in self.client.games[interaction.user.id][-2]] # type: ignore
-            d_fver_d = [num for num in self.client.games[interaction.user.id][-3]] # type: ignore
+            dealer_hand = self.client.games[interaction.user.id][2] 
+            d_fver_p = [num for num in self.client.games[interaction.user.id][-2]] 
+            d_fver_d = [num for num in self.client.games[interaction.user.id][-3]] 
 
-            del self.client.games[interaction.user.id] # type: ignore
+            del self.client.games[interaction.user.id] 
 
-            async with self.client.pool_connection.acquire() as conn:  # type: ignore
+            async with self.client.pool_connection.acquire() as conn:  
                 conn: asqlite_Connection
 
                 bj_lose = await conn.execute('SELECT bjl FROM bank WHERE userID = ?', (interaction.user.id,))
@@ -592,13 +592,13 @@ class BlackjackUi(discord.ui.View):
                                                                           f"**Total** - `{sum(dealer_hand)}`")
                 win.set_author(name=f"{interaction.user.name}'s winning blackjack game",
                                icon_url=interaction.user.display_avatar.url)
-                await interaction.response.edit_message(content=None, embed=win, view=None) # type: ignore
+                await interaction.response.edit_message(content=None, embed=win, view=None) 
 
         else:
 
-            player_hand = self.client.games[interaction.user.id][1] # type: ignore
-            d_fver_p = [number for number in self.client.games[interaction.user.id][-2]] # type: ignore
-            necessary_show = self.client.games[interaction.user.id][-3][0] # type: ignore
+            player_hand = self.client.games[interaction.user.id][1] 
+            d_fver_p = [number for number in self.client.games[interaction.user.id][-2]] 
+            necessary_show = self.client.games[interaction.user.id][-3][0] 
             ts = sum(player_hand)
 
             prg = discord.Embed(colour=0x2B2D31,
@@ -610,7 +610,7 @@ class BlackjackUi(discord.ui.View):
 
             prg.set_footer(text="K, Q, J = 10  |  A = 1 or 11")
             prg.set_author(icon_url=interaction.user.display_avatar.url, name=f"{interaction.user.name}'s blackjack game")
-            await interaction.response.edit_message( # type: ignore
+            await interaction.response.edit_message( 
                 content="Press **Hit** to hit, **Stand** to finalize your deck or "
                         "**Forfeit** to end your hand prematurely.", embed=prg, view=self)
 
@@ -619,10 +619,10 @@ class BlackjackUi(discord.ui.View):
 
         await self.disable_all_items()
 
-        deck = self.client.games[interaction.user.id][0] # type: ignore
-        player_hand = self.client.games[interaction.user.id][1] # type: ignore
-        dealer_hand = self.client.games[interaction.user.id][2] # type: ignore
-        namount = self.client.games[interaction.user.id][-1] # type: ignore
+        deck = self.client.games[interaction.user.id][0] 
+        player_hand = self.client.games[interaction.user.id][1] 
+        dealer_hand = self.client.games[interaction.user.id][2] 
+        namount = self.client.games[interaction.user.id][-1] 
 
         dealer_total = calculate_hand(dealer_hand)
 
@@ -631,18 +631,18 @@ class BlackjackUi(discord.ui.View):
 
             dealer_hand.append(popped)
 
-            self.client.games[interaction.user.id][-3].append(display_user_friendly_card_format(popped)) # type: ignore
+            self.client.games[interaction.user.id][-3].append(display_user_friendly_card_format(popped)) 
 
             dealer_total = calculate_hand(dealer_hand)
 
         player_sum = sum(player_hand)
-        d_fver_p = self.client.games[interaction.user.id][-2] # type: ignore
-        d_fver_d = self.client.games[interaction.user.id][-3] # type: ignore
-        del self.client.games[interaction.user.id] # type: ignore
+        d_fver_p = self.client.games[interaction.user.id][-2] 
+        d_fver_d = self.client.games[interaction.user.id][-3] 
+        del self.client.games[interaction.user.id] 
 
         if dealer_total > 21:
             self.finished = True
-            async with self.client.pool_connection.acquire() as conn:  # type: ignore
+            async with self.client.pool_connection.acquire() as conn:  
                 conn: asqlite_Connection
 
                 bj_lose = await conn.execute('SELECT bjl FROM bank WHERE userID = ?', (interaction.user.id,))
@@ -669,11 +669,11 @@ class BlackjackUi(discord.ui.View):
                                                                       f"**Total** - `{dealer_total}`")
 
             win.set_author(icon_url=interaction.user.display_avatar.url, name=f"{interaction.user.name}'s winning blackjack game")
-            await interaction.response.edit_message(content=None, embed=win, view=None) # type: ignore
+            await interaction.response.edit_message(content=None, embed=win, view=None) 
 
         elif dealer_total > sum(player_hand):
             self.finished = True
-            async with self.client.pool_connection.acquire() as conn:  # type: ignore
+            async with self.client.pool_connection.acquire() as conn:  
                 conn: asqlite_Connection
 
                 bj_win = await conn.execute('SELECT bjw FROM bank WHERE userID = ?', (interaction.user.id,))
@@ -696,11 +696,11 @@ class BlackjackUi(discord.ui.View):
             loser.add_field(name=f"{interaction.guild.me.name} (Dealer)", value=f"**Cards** - {' '.join(d_fver_d)}\n"
                                                                         f"**Total** - `{dealer_total}`")
             loser.set_author(icon_url=interaction.user.display_avatar.url, name=f"{interaction.user.name}'s losing blackjack game")
-            await interaction.response.edit_message(content=None, embed=loser, view=None) # type: ignore
+            await interaction.response.edit_message(content=None, embed=loser, view=None) 
 
         elif dealer_total < sum(player_hand):
             self.finished = True
-            async with self.client.pool_connection.acquire() as conn:  # type: ignore
+            async with self.client.pool_connection.acquire() as conn:  
                 conn: asqlite_Connection
 
                 bj_lose = await conn.execute('SELECT bjl FROM bank WHERE userID = ?', (interaction.user.id,))
@@ -725,10 +725,10 @@ class BlackjackUi(discord.ui.View):
             win.add_field(name=f"{interaction.guild.me.name} (Dealer)", value=f"**Cards** - {' '.join(d_fver_d)}\n"
                                                                       f"**Total** - `{dealer_total}`")
             win.set_author(icon_url=interaction.user.display_avatar.url, name=f"{interaction.user.name}'s winning blackjack game")
-            await interaction.response.edit_message(content=None, embed=win, view=None) # type: ignore
+            await interaction.response.edit_message(content=None, embed=win, view=None) 
         else:
             self.finished = True
-            async with self.client.pool_connection.acquire() as conn:  # type: ignore
+            async with self.client.pool_connection.acquire() as conn:  
                 conn: asqlite_Connection
                 wallet_amt = await Economy.get_wallet_data_only(interaction.user, conn)
             tie = discord.Embed(colour=discord.Colour.yellow(),
@@ -739,22 +739,22 @@ class BlackjackUi(discord.ui.View):
             tie.add_field(name=f"{interaction.guild.me.name} (Dealer)", value=f"**Cards** - {' '.join(d_fver_d)}\n"
                                                                       f"**Total** - `{dealer_total}`")
             tie.set_author(icon_url=interaction.user.display_avatar.url, name=f"{interaction.user.name}'s blackjack game")
-            await interaction.response.edit_message(content=None, embed=tie, view=None) # type: ignore
+            await interaction.response.edit_message(content=None, embed=tie, view=None) 
 
     @discord.ui.button(label='Forfeit', style=discord.ButtonStyle.blurple)
     async def forfeit_bj(self, interaction: discord.Interaction, button: discord.ui.Button):
         self.finished = True
         await self.disable_all_items()
-        namount = self.client.games[interaction.user.id][-1] # type: ignore
+        namount = self.client.games[interaction.user.id][-1] 
         namount = namount // 2
-        dealer_total = sum(self.client.games[interaction.user.id][2]) # type: ignore
-        player_sum = sum(self.client.games[interaction.user.id][1]) # type: ignore
-        d_fver_p = self.client.games[interaction.user.id][-2] # type: ignore
-        d_fver_d = self.client.games[interaction.user.id][-3] # type: ignore
+        dealer_total = sum(self.client.games[interaction.user.id][2]) 
+        player_sum = sum(self.client.games[interaction.user.id][1]) 
+        d_fver_p = self.client.games[interaction.user.id][-2] 
+        d_fver_d = self.client.games[interaction.user.id][-3] 
 
-        del self.client.games[interaction.user.id] # type: ignore
+        del self.client.games[interaction.user.id] 
 
-        async with self.client.pool_connection.acquire() as conn:  # type: ignore
+        async with self.client.pool_connection.acquire() as conn:  
             conn: asqlite_Connection
 
             bj_win = await conn.execute('SELECT bjw FROM bank WHERE userID = ?', (interaction.user.id,))
@@ -778,7 +778,7 @@ class BlackjackUi(discord.ui.View):
         loser.set_author(icon_url=interaction.user.display_avatar.url,
                          name=f"{interaction.user.name}'s losing blackjack game")
 
-        await interaction.response.edit_message(content=None, embed=loser, view=None) # type: ignore
+        await interaction.response.edit_message(content=None, embed=loser, view=None) 
 
 class HighLow(discord.ui.View):
     """View for the Highlow command and its associated functions."""
@@ -803,14 +803,14 @@ class HighLow(discord.ui.View):
         if interaction.user == self.interaction.user:
             return True
 
-        await interaction.response.send_message( # type: ignore
+        await interaction.response.send_message( 
             content=f"This is not your highlow game {interaction.user.display_name}! Make one yourself.",
             ephemeral=True, delete_after=5.5)
         return False
 
     @discord.ui.button(label='Lower', style=discord.ButtonStyle.blurple)
     async def low(self, interaction: discord.Interaction, button: discord.ui.Button):
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if self.true_value < self.hint_provided:
@@ -829,7 +829,7 @@ class HighLow(discord.ui.View):
                                     colour=discord.Color.brand_green())
                 win.set_author(name=f"{interaction.user.name}'s winning high-low game",
                                icon_url=interaction.user.display_avatar.url)
-                await interaction.response.edit_message(embed=win, view=self) # type: ignore
+                await interaction.response.edit_message(embed=win, view=self) 
             else:
                 new_amount = await Economy.update_bank_new(interaction.user, conn, -self.their_bet)
                 await self.make_clicked_blurple_only(button)
@@ -841,11 +841,11 @@ class HighLow(discord.ui.View):
                                      colour=discord.Color.brand_red())
                 lose.set_author(name=f"{interaction.user.name}'s losing high-low game",
                                 icon_url=interaction.user.display_avatar.url)
-                await interaction.response.edit_message(embed=lose, view=self) # type: ignore
+                await interaction.response.edit_message(embed=lose, view=self) 
 
     @discord.ui.button(label='JACKPOT!', style=discord.ButtonStyle.blurple)
     async def jackpot(self, interaction: discord.Interaction, button: discord.ui.Button):
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if self.hint_provided == self.true_value:
@@ -864,7 +864,7 @@ class HighLow(discord.ui.View):
                                     colour=discord.Color.brand_green())
                 win.set_author(name=f"{interaction.user.name}'s winning high-low game",
                                icon_url=interaction.user.display_avatar.url)
-                await interaction.response.edit_message(embed=win, view=self) # type: ignore
+                await interaction.response.edit_message(embed=win, view=self) 
             else:
                 new_bal = await Economy.update_bank_new(interaction.user, conn, -self.their_bet)
                 await self.make_clicked_blurple_only(button)
@@ -877,11 +877,11 @@ class HighLow(discord.ui.View):
                 lose.set_author(name=f"{interaction.user.name}'s losing high-low game",
                                 icon_url=interaction.user.display_avatar.url)
 
-                await interaction.response.edit_message(embed=lose, view=self) # type: ignore
+                await interaction.response.edit_message(embed=lose, view=self) 
 
     @discord.ui.button(label='Higher', style=discord.ButtonStyle.blurple)
     async def high(self, interaction: discord.Interaction, button: discord.ui.Button):
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if self.true_value > self.hint_provided:
@@ -900,7 +900,7 @@ class HighLow(discord.ui.View):
                                     colour=discord.Color.brand_green())
                 win.set_author(name=f"{interaction.user.name}'s winning high-low game",
                                icon_url=interaction.user.display_avatar.url)
-                await interaction.response.edit_message(embed=win, view=self) # type: ignore
+                await interaction.response.edit_message(embed=win, view=self) 
             else:
                 new_bal = await Economy.update_bank_new(interaction.user, conn, -self.their_bet)
                 await self.make_clicked_blurple_only(button)
@@ -912,7 +912,7 @@ class HighLow(discord.ui.View):
                                      colour=discord.Color.brand_red())
                 lose.set_author(name=f"{interaction.user.name}'s losing high-low game",
                                 icon_url=interaction.user.display_avatar.url)
-                await interaction.response.edit_message(embed=lose, view=self) # type: ignore
+                await interaction.response.edit_message(embed=lose, view=self) 
 
 
 class UpdateInfo(discord.ui.Modal, title='Update your Profile'):
@@ -928,11 +928,11 @@ class UpdateInfo(discord.ui.Modal, title='Update your Profile'):
         if self.bio.value == "delete":
             res = modify_profile("delete", f"{interaction.user.id} bio", "placeholder")
             if res == 0:
-                return await interaction.response.send_message(  # type: ignore
+                return await interaction.response.send_message(  
                     embed=membed("<:warning_nr:1195732155544911882> You don't have a bio yet. Add one first."))
 
             else:
-                return await interaction.response.send_message(  # type: ignore
+                return await interaction.response.send_message(  
                     embed=membed(f'## <:trim:1195732275283894292> Your bio has been removed.\n'
                                  f'The changes have taken effect immediately.'))
 
@@ -940,7 +940,7 @@ class UpdateInfo(discord.ui.Modal, title='Update your Profile'):
         phrases = "updated your" if get_profile_key_value(f"{interaction.user.id} bio") is not None else "created a new"
         modify_profile("update", f"{interaction.user.id} bio", self.bio.value)
 
-        return await interaction.response.send_message( # type: ignore
+        return await interaction.response.send_message( 
             embed=membed(
                 f"## <:overwrite:1195729262729240666> Successfully {phrases} bio.\n"
                 f"It is now:\n"
@@ -949,7 +949,7 @@ class UpdateInfo(discord.ui.Modal, title='Update your Profile'):
 
     async def on_error(self, interaction: discord.Interaction, error):
 
-        return await interaction.response.send_message( # type: ignore
+        return await interaction.response.send_message( 
             embed=membed(f"Something went wrong.\n\n> {error.__cause__}"))
 
 
@@ -976,7 +976,7 @@ class DropdownLB(discord.ui.Select):
 
         if chosen_choice == 'Bank + Wallet':
 
-            async with self.client.pool_connection.acquire() as conn: # type: ignore
+            async with self.client.pool_connection.acquire() as conn: 
                 conn: asqlite_Connection = conn
 
                 data = await conn.execute(
@@ -1009,11 +1009,11 @@ class DropdownLB(discord.ui.Select):
                     text=f"Ranked globally",
                     icon_url=self.client.user.avatar.url)
 
-            await interaction.response.edit_message(content=None, embed=lb, view=self.view) # type: ignore
+            await interaction.response.edit_message(content=None, embed=lb, view=self.view) 
 
         elif chosen_choice == 'Wallet':
 
-            async with self.client.pool_connection.acquire() as conn: # type: ignore
+            async with self.client.pool_connection.acquire() as conn: 
                 conn: asqlite_Connection = conn
 
                 data = await conn.execute(
@@ -1045,10 +1045,10 @@ class DropdownLB(discord.ui.Select):
                     text=f"Ranked globally",
                     icon_url=self.client.user.avatar.url)
 
-            await interaction.response.edit_message(content=None, embed=lb, view=self.view) # type: ignore
+            await interaction.response.edit_message(content=None, embed=lb, view=self.view) 
 
         elif chosen_choice == 'Bank':
-            async with self.client.pool_connection.acquire() as conn: # type: ignore
+            async with self.client.pool_connection.acquire() as conn: 
                 conn: asqlite_Connection = conn
 
                 data = await conn.execute(
@@ -1080,10 +1080,10 @@ class DropdownLB(discord.ui.Select):
                     text=f"Ranked globally",
                     icon_url=self.client.user.avatar.url)
 
-            await interaction.response.edit_message(content=None, embed=lb, view=self.view) # type: ignore
+            await interaction.response.edit_message(content=None, embed=lb, view=self.view) 
 
         else:
-            async with self.client.pool_connection.acquire() as conn: # type: ignore
+            async with self.client.pool_connection.acquire() as conn: 
                 conn: asqlite_Connection = conn
 
                 data = await conn.execute(
@@ -1116,7 +1116,7 @@ class DropdownLB(discord.ui.Select):
                     text=f"Ranked globally",
                     icon_url=self.client.user.avatar.url)
 
-            await interaction.response.edit_message(content=None, embed=lb, view=self.view) # type: ignore
+            await interaction.response.edit_message(content=None, embed=lb, view=self.view) 
 
 class Leaderboard(discord.ui.View):
     def __init__(self, client: commands.Bot):
@@ -1128,7 +1128,7 @@ class Leaderboard(discord.ui.View):
         for item in self.children:
             item.disabled = True
 
-        await self.message.edit(view=self) # type: ignore
+        await self.message.edit(view=self) 
 
 
 class Economy(commands.Cog):
@@ -1160,7 +1160,7 @@ class Economy(commands.Cog):
 
     async def fetch_tatsu_profile(self, user_id: int):
         """Get tatsu data associated with a given user."""
-        repeat = ApiWrapper(key=self.client.TATSU_API_KEY)  # type: ignore
+        repeat = ApiWrapper(key=self.client.TATSU_API_KEY)  
         repeat = await repeat.get_profile(user_id)
         return repeat
 
@@ -1168,7 +1168,7 @@ class Economy(commands.Cog):
         if their_pmulti in {"0", 0}:
             hook_id = get_profile_key_value(f"{interaction.channel.id} webhook")
             if hook_id is None:
-                async with self.client.session.get("https://i.imgur.com/3aMsyXI.jpg") as resp:  # type: ignore
+                async with self.client.session.get("https://i.imgur.com/3aMsyXI.jpg") as resp:  
                     avatar_data = await resp.read()
                 hook = await interaction.channel.create_webhook(name='Notify', avatar=avatar_data)
                 modify_profile("update", f"{interaction.channel.id} webhook", hook.id)
@@ -1182,7 +1182,7 @@ class Economy(commands.Cog):
                                custom_text: str):
         hook_id = get_profile_key_value(f"{interaction.channel.id} webhook")
         if hook_id is None:
-            async with self.client.session.get("https://i.imgur.com/3aMsyXI.jpg") as resp:  # type: ignore
+            async with self.client.session.get("https://i.imgur.com/3aMsyXI.jpg") as resp:  
                 avatar_data = await resp.read()
             hook = await interaction.channel.create_webhook(name='Notify', avatar=avatar_data)
             modify_profile("update", f"{interaction.channel.id} webhook", hook.id)
@@ -1500,7 +1500,7 @@ class Economy(commands.Cog):
 
     @commands.Cog.listener()
     async def on_app_command_completion(self, interaction: discord.Interaction, command):
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
             if await self.can_call_out(interaction.user, conn):
                 return
@@ -1519,14 +1519,14 @@ class Economy(commands.Cog):
     @app_commands.checks.dynamic_cooldown(owners_nolimit)
     async def my_multi(self, interaction: discord.Interaction, user_name: Optional[discord.Member]):
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if user_name is None:
                 user_name = interaction.user
 
             if await Economy.can_call_out(user_name, conn):
-                return await interaction.response.send_message(embed=NOT_REGISTERED) # type: ignore
+                return await interaction.response.send_message(embed=NOT_REGISTERED) 
             their_multi = await Economy.get_pmulti_data_only(user_name, conn)
 
             if their_multi[0] == 0 and (user_name.id == interaction.user.id):
@@ -1563,7 +1563,7 @@ class Economy(commands.Cog):
                 multi_own.set_author(name=f'Viewing {user_name.name}\'s multipliers',
                                      icon_url=user_name.display_avatar.url)
 
-            await interaction.response.send_message(embed=multi_own) # type: ignore
+            await interaction.response.send_message(embed=multi_own) 
 
     share = app_commands.Group(name='share', description='share different assets with others.',
                                guild_only=True, guild_ids=APP_GUILDS_ID)
@@ -1576,11 +1576,11 @@ class Economy(commands.Cog):
     async def give_robux(self, interaction: discord.Interaction, other: discord.Member, amount: str):
         inter_user = interaction.user
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if not (await self.can_call_out_either(inter_user, other, conn)):
-                return await interaction.response.send_message(embed=NOT_REGISTERED) # type: ignore
+                return await interaction.response.send_message(embed=NOT_REGISTERED) 
             else:
                 real_amount = determine_exponent(amount)
                 wallet_amt_host = await Economy.get_wallet_data_only(inter_user, conn)
@@ -1589,14 +1589,14 @@ class Economy(commands.Cog):
                     if real_amount.lower() == 'all' or real_amount.lower() == 'max':
                         real_amount = wallet_amt_host
                     else:
-                        return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
+                        return await interaction.response.send_message(embed=ERR_UNREASON) 
                     host_amt = await self.update_bank_new(inter_user, conn, -int(real_amount))
                     recp_amt = await self.update_bank_new(other, conn, int(real_amount))
                 else:
                     if real_amount == 0:
-                        return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
+                        return await interaction.response.send_message(embed=ERR_UNREASON) 
                     elif real_amount > wallet_amt_host:
-                        return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
+                        return await interaction.response.send_message(embed=ERR_UNREASON) 
                     else:
                         host_amt = await self.update_bank_new(inter_user, conn, -int(real_amount))
                         recp_amt = await self.update_bank_new(other, conn, int(real_amount))
@@ -1610,7 +1610,7 @@ class Economy(commands.Cog):
                 embed.set_thumbnail(url="https://i.imgur.com/RxQuE8T.png")
                 embed.set_author(name=f'Transaction made by {inter_user.name}',
                                  icon_url=inter_user.display_avatar.url)
-                return await interaction.response.send_message(embed=embed) # type: ignore
+                return await interaction.response.send_message(embed=embed) 
 
     @share.command(name='items', description='share items with another user.')
     @app_commands.describe(item_name='the name of the item you want to share.',
@@ -1621,18 +1621,18 @@ class Economy(commands.Cog):
                          amount: Literal[1, 2, 3, 4, 5], username: discord.Member):
         primm = interaction.user
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
             item_name = item_name.replace(" ", "_")
             if not(await self.can_call_out_either(primm, username, conn)):
                 embed = discord.Embed(description=f'Either you or {username.name} does not have an account.\n'
                                                   f'</balance:1179817617435926686> to register.',
                                       colour=0x2F3136)
-                return await interaction.response.send_message(embed=embed) # type: ignore
+                return await interaction.response.send_message(embed=embed) 
             else:
                 quantity = await self.update_inv_new(primm, 0, item_name, conn)
                 if amount > quantity[0]:
-                    return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
+                    return await interaction.response.send_message(embed=ERR_UNREASON) 
                 else:
                     receiver = await self.update_inv_new(username, +amount, item_name, conn)
                     new_after_transaction = quantity[0] - amount
@@ -1648,7 +1648,7 @@ class Economy(commands.Cog):
                     transaction_success.set_author(name=f'Transaction made by {primm.name}',
                                                    icon_url=primm.display_avatar.url)
 
-                    await interaction.response.send_message(embed=transaction_success) # type: ignore
+                    await interaction.response.send_message(embed=transaction_success) 
 
     showcase = app_commands.Group(name="showcase", description="manage your showcased items.", guild_only=True,
                                   guild_ids=APP_GUILDS_ID)
@@ -1656,7 +1656,7 @@ class Economy(commands.Cog):
     @showcase.command(name="view", description="view your item showcase.")
     @app_commands.checks.cooldown(1, 5)
     async def view_showcase(self, interaction: discord.Interaction):
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
@@ -1698,7 +1698,7 @@ class Economy(commands.Cog):
             if should_warn_user:
                 showbed.set_footer(text="You can add more items to your showcase.")
 
-            await interaction.response.send_message(embed=showbed) # type: ignore
+            await interaction.response.send_message(embed=showbed) 
 
     @showcase.command(name="add", description="add an item to your showcase.")
     @app_commands.checks.cooldown(1, 10)
@@ -1708,11 +1708,11 @@ class Economy(commands.Cog):
                             position: int,
                             item_name: Literal['Keycard', 'Trophy', 'Clan License', 'Resistor', 'Amulet',
                             'Dynamic Item', 'Hyperion', 'Crisis', 'Odd Eye']):
-        async with self.client.pool_connection.acquire() as conn:  # type: ignore
+        async with self.client.pool_connection.acquire() as conn:  
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
+                return await interaction.response.send_message(embed=self.not_registered) 
 
             item_name = "_".join(item_name.split(' '))
             item_qty = await self.get_one_inv_data_new(interaction.user, item_name, conn)
@@ -1727,13 +1727,13 @@ class Economy(commands.Cog):
                         embed=membed("You already have the maximum of 3 showcase slots."))
 
                 if item_qty == 0:
-                    return await interaction.response.send_message( # type: ignore
+                    return await interaction.response.send_message( 
                         embed=membed("You cannot flex on someone with something you don't even have."))
 
                 if item_name in showcase:
                     item_index = showcase.index(item_name)
                     if item_index == position-1:
-                        return await interaction.response.send_message( # type: ignore
+                        return await interaction.response.send_message( 
                             embed=membed("You already have this item in this slot."))
 
                     showcase[item_index] = "0"
@@ -1774,11 +1774,11 @@ class Economy(commands.Cog):
     async def remove_showcase_item(self, interaction: discord.Interaction,
                            item_name: Literal['Keycard', 'Trophy', 'Clan License', 'Resistor', 'Amulet',
                            'Dynamic Item', 'Hyperion', 'Crisis', 'Odd Eye']):
-        async with self.client.pool_connection.acquire() as conn:  # type: ignore
+        async with self.client.pool_connection.acquire() as conn:  
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered)  # type: ignore
+                return await interaction.response.send_message(embed=self.not_registered)  
 
             item_name = "_".join(item_name.split(' '))
 
@@ -1815,11 +1815,11 @@ class Economy(commands.Cog):
     @app_commands.checks.dynamic_cooldown(owners_nolimit)
     async def view_the_shop(self, interaction: discord.Interaction):
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
+                return await interaction.response.send_message(embed=self.not_registered) 
 
             additional_notes = list()
 
@@ -1884,7 +1884,7 @@ class Economy(commands.Cog):
             cost = item["cost"]
 
             if name == item_name:
-                async with self.client.pool_connection.acquire() as conn:  # type: ignore
+                async with self.client.pool_connection.acquire() as conn:  
                     conn: asqlite_Connection
                     data = await conn.execute(f"SELECT COUNT(*) FROM inventory WHERE {stored} > 0")
                     data = await data.fetchone()
@@ -1904,9 +1904,9 @@ class Economy(commands.Cog):
                 em.add_field(name="Selling price",
                              value=f"<:robux:1146394968882151434> {floor(int(cost) / 4):,}")
 
-                return await interaction.response.send_message(embed=em) # type: ignore
+                return await interaction.response.send_message(embed=em) 
 
-        await interaction.response.send_message(f"There is no item named {item_name}.") # type: ignore
+        await interaction.response.send_message(f"There is no item named {item_name}.") 
 
     profile = app_commands.Group(name='editprofile', description='custom-profile-orientated commands for use.',
                                  guild_only=True, guild_ids=APP_GUILDS_ID)
@@ -1915,43 +1915,43 @@ class Economy(commands.Cog):
     @app_commands.checks.cooldown(1, 30)
     @app_commands.describe(text="maximum of 32 characters allowed")
     async def update_bio_profile(self, interaction: discord.Interaction, text: str):
-        async with self.client.pool_connection.acquire() as conn:  # type: ignore
+        async with self.client.pool_connection.acquire() as conn:  
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(  # type: ignore
+                return await interaction.response.send_message(  
                     embed=self.not_registered)
 
             if len(text) > 32:
-                return await interaction.response.send_message( # type: ignore
+                return await interaction.response.send_message( 
                     embed=membed("Title cannot exceed 32 characters."))
 
             text = sub(r'[\n\t]', '', text)
             await self.change_bank_new(interaction.user, conn, text, "title")
 
-            await interaction.response.send_message( # type: ignore
+            await interaction.response.send_message( 
                 embed=membed(f"### {interaction.user.name}'s Profile - [{text}](https://www.dis.gd/support)\n"
                              f"Your title has been changed. A preview is shown above."))
 
     @profile.command(name='bio', description='add a bio to your profile.')
     @app_commands.checks.cooldown(1, 30)
     async def update_bio_profile(self, interaction: discord.Interaction):
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
-            await interaction.response.send_modal(UpdateInfo()) # type: ignore
+                return await interaction.response.send_message(embed=self.not_registered) 
+            await interaction.response.send_modal(UpdateInfo()) 
 
     @profile.command(name='avatar', description='change your profile avatar.')
     @app_commands.describe(url='the url of the new avatar. leave blank to remove.')
     @app_commands.checks.cooldown(1, 30)
     async def update_avatar_profile(self, interaction: discord.Interaction, url: Optional[str]):
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
+                return await interaction.response.send_message(embed=self.not_registered) 
 
         if url is None:
             res = modify_profile("delete", f"{interaction.user.id} avatar_url", url)
@@ -1960,7 +1960,7 @@ class Economy(commands.Cog):
                     res = "<:warning_nr:1195732155544911882> No custom avatar was found under your account."
                 case _:
                     res = "<:overwrite:1195729262729240666> Your avatar was removed."
-            return await interaction.response.send_message(embed=membed(res)) # type: ignore
+            return await interaction.response.send_message(embed=membed(res)) 
 
         successful = discord.Embed(colour=0x2B2D31,
                                    description=f"## <:overwrite:1195729262729240666> Your custom has been added.\n"
@@ -1968,12 +1968,12 @@ class Economy(commands.Cog):
                                                f"- If you can't see it, change it!")
         successful.set_thumbnail(url=url)
         modify_profile("update", f"{interaction.user.id} avatar_url", url)
-        await interaction.response.send_message(embed=successful) # type: ignore
+        await interaction.response.send_message(embed=successful) 
 
     @update_avatar_profile.error
     async def uap_error(self, interaction: discord.Interaction, err: discord.app_commands.AppCommandError):
         modify_profile("delete", f"{interaction.user.id} avatar_url", "who cares")
-        return await interaction.response.send_message( # type: ignore
+        return await interaction.response.send_message( 
             embed=membed(
                 f"<:warning_nr:1195732155544911882> The avatar url requested for could not be added:\n"
                 f"- The URL provided was not well formed.\n"
@@ -1987,16 +1987,16 @@ class Economy(commands.Cog):
     @app_commands.checks.cooldown(1, 30)
     async def update_vis_profile(self, interaction: discord.Interaction,
                                  mode: Literal['public', 'private']):
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
+                return await interaction.response.send_message(embed=self.not_registered) 
 
         modify_profile("update", f"{interaction.user.id} vis", mode)
         cemoji = {"private": "<:privatee:1195728566919385088>",
                   "public": "<:publice:1195728479715590205>"}
         cemoji = cemoji.get(mode)
-        await interaction.response.send_message(f"{cemoji} Your profile is now {mode}.", ephemeral=True, delete_after=7.5) # type: ignore
+        await interaction.response.send_message(f"{cemoji} Your profile is now {mode}.", ephemeral=True, delete_after=7.5) 
 
     slay = app_commands.Group(name='slay', description='manage your slay.',
                               guild_only=True,
@@ -2009,8 +2009,8 @@ class Economy(commands.Cog):
                            investment="how much robux your willing to spend on this slay (no shortcuts)")
     async def hire_slv(self, interaction: discord.Interaction, user: Optional[discord.Member],
                        new_slay_name: Optional[str], gender: Literal["male", "female"], investment: int):
-        await interaction.response.defer(thinking=True) # type: ignore
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        await interaction.response.defer(thinking=True) 
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
@@ -2079,16 +2079,16 @@ class Economy(commands.Cog):
                            slay_purge='the name of your slay, if you didn\'t pick a user.')
     async def abandon_slv(self, interaction: discord.Interaction, user: Optional[discord.Member],
                           slay_purge: Optional[str]):
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
                 return await interaction.followup.send(embed=self.not_registered)
 
             if (user is None) and (slay_purge is None):
-                return await interaction.response.send_message("You did not input any slay.") # type: ignore
+                return await interaction.response.send_message("You did not input any slay.") 
             elif (slay_purge is not None) and (user is not None):
-                return await interaction.response.send_message("You cannot name your slay if the user has also " # type: ignore
+                return await interaction.response.send_message("You cannot name your slay if the user has also " 
                                                                "been inputted. Remove this argument if needed.")
             else:
                 slays = await self.get_slays(conn, interaction.user)
@@ -2098,7 +2098,7 @@ class Economy(commands.Cog):
 
                 await self.delete_slay(conn, interaction.user, slay_purge)
 
-                return await interaction.response.send_message( # type: ignore
+                return await interaction.response.send_message( 
                 embed=membed(f"Attempted to remove {slay_purge} from your owned slays.\n"
                              f" - {len(slays)}/6 total slay slots consumed."))
 
@@ -2107,7 +2107,7 @@ class Economy(commands.Cog):
     @app_commands.describe(user='the user to view the slays of')
     async def view_all_slays(self, interaction: discord.Interaction, user: Optional[discord.Member]):
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if user is None:
@@ -2123,7 +2123,7 @@ class Economy(commands.Cog):
 
             if len(slays) == 0:
                 embed.add_field(name="Nothingness.", value="This user has no slays yet.", inline=False)
-                return await interaction.response.send_message(embed=embed) # type: ignore
+                return await interaction.response.send_message(embed=embed) 
 
             for slay in slays:
                 if 66 <= slay[4] <= 100:
@@ -2136,15 +2136,15 @@ class Economy(commands.Cog):
                                                               f'\n{ARROW}{stats.get(slay[5])}')
 
             embed.set_footer(text=f"{len(slays)}/6 slay slots consumed")
-            await interaction.response.send_message(embed=embed) # type: ignore
+            await interaction.response.send_message(embed=embed) 
 
     @slay.command(name='work', description="assign your slays to do tasks for you.")
     @app_commands.describe(duration="the time spent working (e.g, 18h or 1d 3h)")
     async def make_slay_work_pay(self, interaction: discord.Interaction, duration: str):
-        await interaction.response.defer(thinking=True) # type: ignore
+        await interaction.response.defer(thinking=True) 
 
         try:
-            async with self.client.pool_connection.acquire() as conn: # type: ignore
+            async with self.client.pool_connection.acquire() as conn: 
                 conn: asqlite_Connection
 
                 if await self.can_call_out(interaction.user, conn):
@@ -2287,32 +2287,32 @@ class Economy(commands.Cog):
     async def use_item(self, interaction: discord.Interaction,
                        item: Literal['Keycard', 'Trophy', 'Clan License', 'Resistor', 'Amulet', 'Dynamic Item', 'Hyperion', 'Crisis', 'Odd Eye']):
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user,conn):
-                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
+                return await interaction.response.send_message(embed=self.not_registered) 
 
             item = item.replace(" ", "_")
             quantity = await self.get_one_inv_data_new(interaction.user, item, conn)
 
             if not quantity:
-                return await interaction.response.send_message( # type: ignore
+                return await interaction.response.send_message( 
                     embed=membed(f"You don't have this item in your inventory."))
 
             match item:
                 case 'Keycard' | 'Resistor' | 'Hyperion' | 'Crisis':
-                    return await interaction.response.send_message(  # type: ignore
+                    return await interaction.response.send_message(  
                         content="This item cannot be used. The effects are always passively active!")
                 case 'Trophy':
                     if quantity > 1:
                         content = f'\nThey have **{quantity}** of them, WHAT A BADASS'
                     else:
                         content = ''
-                    return await interaction.response.send_message( # type: ignore
+                    return await interaction.response.send_message( 
                         f"{interaction.user.name} is flexing on you all with their <:tr1:1165936712468418591> **~~PEPE~~ TROPHY**{content}")
                 case _:
-                    return await interaction.response.send_message( # type: ignore
+                    return await interaction.response.send_message( 
                         embed=membed("The functions for this item aren't available.\n"
                                      "If you wish to submit an idea for what these items do, "
                                      "comment on [this issue on our Github.](https://github.com/SGA-A/c2c/issues/12)")
@@ -2326,10 +2326,10 @@ class Economy(commands.Cog):
                       job_name: Literal['Plumber', 'Cashier', 'Fisher', 'Janitor',
                                         'Youtuber', 'Police', 'I want to resign!']):
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
+                return await interaction.response.send_message(embed=self.not_registered) 
 
             cooldown = await self.fetch_cooldown(conn, user=interaction.user, cooldown_type="job_change")
             current_job = await self.get_job_data_only(interaction.user, conn)
@@ -2348,10 +2348,10 @@ class Economy(commands.Cog):
                                                            new_cd=ncd)
 
                                 await self.change_job_new(interaction.user, conn, job_name='None')
-                                return await interaction.response.send_message( # type: ignore
+                                return await interaction.response.send_message( 
                                     embed=membed(f"Alright, I've removed you from your job.\n"
                                                  f"You cannot apply to another job for the next **48 hours**."))
-                            return await interaction.response.send_message( # type: ignore
+                            return await interaction.response.send_message( 
                                 embed=membed("You're already unemployed!?"))
 
                         ncd = datetime.datetime.now() + datetime.timedelta(days=2)
@@ -2359,10 +2359,10 @@ class Economy(commands.Cog):
                         await self.update_cooldown(conn, user=interaction.user, cooldown_type="job_change", new_cd=ncd)
 
                         await self.change_job_new(interaction.user, conn, job_name=job_name)
-                        return await interaction.response.send_message( # type: ignore
+                        return await interaction.response.send_message( 
                             embed=membed(f"Congratulations, you've been hired.\n"
-                                         f"Starting today, you are working as a {job_name.lower()}."))  # type: ignore
-                    return await interaction.response.send_message( # type: ignore
+                                         f"Starting today, you are working as a {job_name.lower()}."))  
+                    return await interaction.response.send_message( 
                         embed=membed(f"You're already a {job_name.lower()}!"))
 
                 else:
@@ -2379,7 +2379,7 @@ class Economy(commands.Cog):
                         else:
                             response = "You've done the paperwork and have now resigned from your previous job."
 
-                        await interaction.response.send_message( # type: ignore
+                        await interaction.response.send_message( 
                             embed=membed(f"{response}\n"
                                          f"Call this command again to begin your new career.")
                         )
@@ -2389,7 +2389,7 @@ class Economy(commands.Cog):
                                               description=f"You can change your job "
                                                           f"{discord.utils.format_dt(when, 'R')}.",
                                               colour=0x2B2D31)
-                        await interaction.response.send_message(embed=embed) # type: ignore
+                        await interaction.response.send_message(embed=embed) 
 
     @app_commands.command(name='profile', description='view user information and stats.')
     @app_commands.guilds(discord.Object(id=829053898333225010), discord.Object(id=780397076273954886))
@@ -2401,10 +2401,10 @@ class Economy(commands.Cog):
         user = user or interaction.user
         category = category or "Main Profile"
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
 
             if await self.can_call_out(user, conn):
-                return await interaction.response.send_message(embed=NOT_REGISTERED) # type: ignore
+                return await interaction.response.send_message(embed=NOT_REGISTERED) 
 
             ephemerality = False
 
@@ -2416,7 +2416,7 @@ class Economy(commands.Cog):
                 data = await data.fetchone()
 
                 if (get_profile_key_value(f"{user.id} vis") == "private") and (interaction.user.id != user.id):
-                    return await interaction.response.send_message(  # type: ignore
+                    return await interaction.response.send_message(  
                         embed=membed(f"# <:security:1153754206143000596> {user.name}'s profile is protected.\n"
                                      f"Only approved users can view {user.name}'s profile."))
 
@@ -2501,7 +2501,7 @@ class Economy(commands.Cog):
                         procfile.set_thumbnail(url=user.display_avatar.url)
                 else:
                     procfile.set_thumbnail(url=user.display_avatar.url)
-                return await interaction.response.send_message( # type: ignore
+                return await interaction.response.send_message( 
                     embed=procfile, silent=True, ephemeral=ephemerality)
             else:
 
@@ -2547,7 +2547,7 @@ class Economy(commands.Cog):
                                       f"Win: {winbl}% ({data[4]})")
                 stats.set_footer(text="The number next to the name is how many matches are recorded")
 
-                await interaction.response.send_message(embed=stats)  # type: ignore
+                await interaction.response.send_message(embed=stats)  
                 resp = await interaction.original_response()
                 try:
                     its_sum = total_bets + total_slots + total_blackjacks
@@ -2585,10 +2585,10 @@ class Economy(commands.Cog):
             else:
                 return True
 
-        async with self.client.pool_connection.acquire() as conn:  # type: ignore
+        async with self.client.pool_connection.acquire() as conn:  
             conn: asqlite_Connection
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
+                return await interaction.response.send_message(embed=self.not_registered) 
 
             real_amount = determine_exponent(robux)
             wallet_amt = await self.get_wallet_data_only(interaction.user, conn)
@@ -2601,7 +2601,7 @@ class Economy(commands.Cog):
                         real_amount = 50000000
 
             if not (is_valid(int(real_amount), wallet_amt)):
-                return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
+                return await interaction.response.send_message(embed=ERR_UNREASON) 
 
             number = randint(1, 100)
             hint = randint(1, 100)
@@ -2612,7 +2612,7 @@ class Economy(commands.Cog):
             query.set_author(name=f"{interaction.user.name}'s high-low game",
                              icon_url=interaction.user.display_avatar.url)
             query.set_footer(text="The jackpot button is if you think it is the same!")
-            await interaction.response.send_message( # type: ignore
+            await interaction.response.send_message( 
                 view=HighLow(interaction, self.client, hint_provided=hint, bet=real_amount, value=number),
                 embed=query)
 
@@ -2627,11 +2627,11 @@ class Economy(commands.Cog):
     @app_commands.describe(amount='an integer to bet upon. Supports Shortcuts (max, all, exponents).')
     async def slots(self, interaction: discord.Interaction, amount: str):
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                await interaction.response.send_message(embed=self.not_registered) # type: ignore
+                await interaction.response.send_message(embed=self.not_registered) 
 
         # --------------- Checks before betting i.e. has keycard, meets bet constraints. -------------
         data = await self.get_one_inv_data_new(interaction.user, "Keycard", conn)
@@ -2653,26 +2653,26 @@ class Economy(commands.Cog):
                 else:
                     amount = min(50_000_000, wallet_amt)
             else:
-                return await interaction.response.send_message(embed=ERR_UNREASON)  # type: ignore
+                return await interaction.response.send_message(embed=ERR_UNREASON)  
 
         # --------------- Contains checks before betting i.e. has keycard, meets bet constraints. -------------
         if data >= 1:
             if not (30000 <= amount <= 75000000):
-                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=(  # type: ignore
+                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=(  
                     f'## You did not meet the slot machine criteria.\n'
                     f'- You wanted to bet {CURRENCY}**{amount:,}**\n'
                     f' - A minimum bet of {CURRENCY}**30,000** must be made\n'
                     f' - A maximum bet of {CURRENCY}**75,000,000** can only be made.'
                 )))
             elif amount > wallet_amt:
-                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=(  # type: ignore
+                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=(  
                     f'Cannot perform this action.\n'
                     f'You only have {CURRENCY}**{wallet_amt:,}**.\n'
                     f'You\'ll need {CURRENCY}**{amount - wallet_amt:,}** more in your wallet first.'
                 )))
         else:
             if not (50000 <= amount <= 50000000):
-                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=(  # type: ignore
+                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=(  
                     f'## You did not meet the slot machine criteria.\n'
                     f'- You wanted to bet {CURRENCY}**{amount:,}**\n'
                     f' - A minimum bet of {CURRENCY}**50,000** must be made.\n'
@@ -2680,7 +2680,7 @@ class Economy(commands.Cog):
                 )))
 
             elif amount > wallet_amt:
-                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=(  # type: ignore
+                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=(  
                     f"## Cannot perform this action.\n"
                     f"You only have {CURRENCY}**{wallet_amt:,}**.\n"
                     f"You'll need {CURRENCY}**{amount - wallet_amt:,}** more in your wallet first."
@@ -2748,7 +2748,7 @@ class Economy(commands.Cog):
             embed.set_author(name=f"{interaction.user.name}'s losing slot machine",
                              icon_url=interaction.user.display_avatar.url)
 
-        await interaction.response.send_message(embed=embed) # type: ignore
+        await interaction.response.send_message(embed=embed) 
 
     @app_commands.command(name='inventory', description='view your currently owned items.')
     @app_commands.guilds(discord.Object(id=829053898333225010), discord.Object(id=780397076273954886))
@@ -2757,13 +2757,13 @@ class Economy(commands.Cog):
         member = member or interaction.user
 
         if member.bot and member.id != self.client.user.id:
-            return await interaction.response.send_message(embed=membed("Bots do not have accounts."), delete_after=5.0) # type: ignore
+            return await interaction.response.send_message(embed=membed("Bots do not have accounts."), delete_after=5.0) 
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if await self.can_call_out(member, conn):
-                return await interaction.response.send_message(embed=NOT_REGISTERED) # type: ignore
+                return await interaction.response.send_message(embed=NOT_REGISTERED) 
 
             em = discord.Embed(color=0x2F3136)
             length = 3
@@ -2795,7 +2795,7 @@ class Economy(commands.Cog):
 
                 em.add_field(
                     name=f"Nothingness.", value=f"No items were found from this user.", inline=False)
-                return await interaction.response.send_message(embed=em) # type: ignore
+                return await interaction.response.send_message(embed=em) 
 
             async def get_page_part(page: int):
 
@@ -2829,11 +2829,11 @@ class Economy(commands.Cog):
         if quantity is None:
             quantity = 1
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
+                return await interaction.response.send_message(embed=self.not_registered) 
 
             wallet_amt = await self.get_wallet_data_only(interaction.user, conn)
 
@@ -2846,7 +2846,7 @@ class Economy(commands.Cog):
                     stock_item = get_stock(item_name)
 
                     if stock_item == 0:
-                        return await interaction.response.send_message( # type: ignore
+                        return await interaction.response.send_message( 
                             embed=membed(f"## Unsuccessful Transaction\n"
                                          f"- The {ie} **{item_name}** is currently out of stock.\n"
                                          f" - Until a user who owns this item chooses to "
@@ -2856,7 +2856,7 @@ class Economy(commands.Cog):
                         proper_name = " ".join(proper_name.split("_"))
                         proper_name = make_plural(proper_name, stock_item)
                         their_name = make_plural(proper_name, quantity)
-                        return await interaction.response.send_message( # type: ignore
+                        return await interaction.response.send_message( 
                             embed=membed(f"## Unsuccessful Transaction\n"
                                          f"There are only **{stock_item}** {ie} **{proper_name.title()}** available.\n"
                                          f"{ARROW}Meaning you cannot possibly buy **{quantity}** {their_name.title()}."))
@@ -2866,7 +2866,7 @@ class Economy(commands.Cog):
                     if wallet_amt < int(total_cost):
                         proper_name = " ".join(proper_name.split("_"))
                         proper_name = make_plural(proper_name, quantity)
-                        return await interaction.response.send_message( # type: ignore
+                        return await interaction.response.send_message( 
                             embed=membed(f"## Unsuccessful Transaction\n"
                                          f"You'll need {CURRENCY}**{total_cost - wallet_amt:,}** more to "
                                          f"purchase {quantity} {ie} **{proper_name.title()}**."))
@@ -2877,7 +2877,7 @@ class Economy(commands.Cog):
 
                     match quantity:
                         case 1:
-                            return await interaction.response.send_message( # type: ignore
+                            return await interaction.response.send_message( 
                                 embed=membed(f"## Success\n"
                                              f"- Purchased **1** {ie} **{item_name}** by paying "
                                              f"{CURRENCY}**{total_cost:,}**.\n"
@@ -2885,7 +2885,7 @@ class Economy(commands.Cog):
                         case _:
                             their_name = ' '.join(proper_name.split("_"))
                             their_name = make_plural(their_name, quantity)
-                            await interaction.response.send_message( # type: ignore
+                            await interaction.response.send_message( 
                                 embed=membed(f"## Success\n"
                                              f"- Purchased **{quantity}** {ie} **{their_name.title()}** by"
                                              f" paying {CURRENCY}**{total_cost:,}**.\n"
@@ -2903,11 +2903,11 @@ class Economy(commands.Cog):
             sell_quantity = 1
 
         name = item_name.replace(" ", "_")
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
+                return await interaction.response.send_message(embed=self.not_registered) 
 
             for item in SHOP_ITEMS:
                 if name == item["name"]:
@@ -2916,12 +2916,12 @@ class Economy(commands.Cog):
                     quantity = await self.update_inv_new(interaction.user, 0, item["name"], conn)
 
                     if quantity[0] < 1:
-                        return await interaction.response.send_message( # type: ignore
+                        return await interaction.response.send_message( 
                             embed=membed(f"You don't have a {ie} **{item_name}** in your inventory."))
 
                     new_quantity = quantity[0] - sell_quantity
                     if new_quantity < 0:
-                        return await interaction.response.send_message( # type: ignore
+                        return await interaction.response.send_message( 
                             f"You are requesting to sell more than what you currently own. Not possible.")
 
                     await self.change_inv_new(interaction.user, new_quantity, item["name"], conn)
@@ -2932,14 +2932,14 @@ class Economy(commands.Cog):
                         case 1:
                             proper_name = item.setdefault('qn', None) or name
                             proper_name = ' '.join(proper_name.split('_'))
-                            return await interaction.response.send_message( # type: ignore
+                            return await interaction.response.send_message( 
                                 embed=membed(f"You just sold 1 {ie} **{proper_name.title()}** and got "
                                              f"<:robux:1146394968882151434> **{cost:,}** in return."))
                         case _:
                             proper_name = item.setdefault('qn', None) or name
                             proper_name = ' '.join(proper_name.split('_'))
                             proper_name = make_plural(proper_name, sell_quantity)
-                            return await interaction.response.send_message( # type: ignore
+                            return await interaction.response.send_message( 
                                 embed=membed(f"You just sold {sell_quantity} {ie} **{proper_name.title()}** and got "
                                              f"<:robux:1146394968882151434> **{cost:,}** in return."))
 
@@ -2947,7 +2947,7 @@ class Economy(commands.Cog):
     @app_commands.guilds(discord.Object(id=829053898333225010), discord.Object(id=780397076273954886))
     async def work(self, interaction: discord.Interaction):
 
-        await interaction.response.defer(thinking=True, ephemeral=True) # type: ignore
+        await interaction.response.defer(thinking=True, ephemeral=True) 
 
         words = {
             "Plumber": [("TOILET", "SINK", "SEWAGE", "SANITATION", "DRAINAGE", "PIPES"), 400000000],
@@ -2963,7 +2963,7 @@ class Economy(commands.Cog):
                        "INTERROGATION"), 1200000000]
         }
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
@@ -3018,11 +3018,11 @@ class Economy(commands.Cog):
     async def find_balance(self, interaction: discord.Interaction, user: Optional[discord.Member]):
         """Returns a user's balance."""
 
-        await interaction.response.defer(thinking=True) # type: ignore
+        await interaction.response.defer(thinking=True) 
 
         user = user or interaction.user
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if await self.can_call_out(user, conn) and (user.id != interaction.user.id):
@@ -3090,16 +3090,16 @@ class Economy(commands.Cog):
         member = member or interaction.user
         if interaction.user.id not in {992152414566232139, 546086191414509599}:
             if (member is not None) and (member != interaction.user):
-                return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
+                return await interaction.response.send_message(embed=ERR_UNREASON) 
         else:
             if member.bot:
-                return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
+                return await interaction.response.send_message(embed=ERR_UNREASON) 
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if await self.can_call_out(member, conn):
-                await interaction.response.send_message( # type: ignore
+                await interaction.response.send_message( 
                     embed=membed(f"Could not find {member.name} in the database."))
             else:
 
@@ -3112,7 +3112,7 @@ class Economy(commands.Cog):
                                                       "cannot recover this data again.",
                                           colour=0x2B2D31)
 
-                    await interaction.response.send_message(embed=embed, view=view)  # type: ignore
+                    await interaction.response.send_message(embed=embed, view=view)  
                     view.msg = await interaction.original_response()
                     return
 
@@ -3128,7 +3128,7 @@ class Economy(commands.Cog):
                                         colour=discord.Colour.brand_green())
                 success.set_footer(text="Some requirements were bypassed.", icon_url=self.client.user.avatar.url)
 
-                await interaction.response.send_message(embed=success) # type: ignore
+                await interaction.response.send_message(embed=success) 
 
     @app_commands.command(name="withdraw", description="withdraw robux from your account.")
     @app_commands.guilds(discord.Object(id=829053898333225010), discord.Object(id=780397076273954886))
@@ -3139,10 +3139,10 @@ class Economy(commands.Cog):
         user = interaction.user
         actual_amount = determine_exponent(robux)
 
-        async with (self.client.pool_connection.acquire() as conn): # type: ignore
+        async with (self.client.pool_connection.acquire() as conn): 
             conn: asqlite_Connection
             if await self.can_call_out(interaction.user, conn):
-                await interaction.response.send_message(embed=self.not_registered) # type: ignore
+                await interaction.response.send_message(embed=self.not_registered) 
             users = await self.get_bank_data_new(user, conn)
 
             bank_amt = users[2]
@@ -3158,8 +3158,8 @@ class Economy(commands.Cog):
                     embed.add_field(name=f"Current Wallet Balance", value=f"\U000023e3 {wallet_new[0]:,}")
                     embed.add_field(name=f"Current Bank Balance", value=f"\U000023e3 {bank_new[0]:,}")
 
-                    return await interaction.response.send_message(embed=embed) # type: ignore
-                return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
+                    return await interaction.response.send_message(embed=embed) 
+                return await interaction.response.send_message(embed=ERR_UNREASON) 
 
             amount_conv = abs(int(actual_amount))
             if amount_conv < 5000:
@@ -3167,14 +3167,14 @@ class Economy(commands.Cog):
                                       description=f"- For performance reasons, a minimum of "
                                                   f"\U000023e3 **5,000** must be withdrawn.\n"
                                                   f" - You wanted to withdraw \U000023e3 **{amount_conv:,}**.\n")
-                return await interaction.response.send_message(embed=embed) # type: ignore
+                return await interaction.response.send_message(embed=embed) 
 
             elif amount_conv > bank_amt:
                 embed = discord.Embed(colour=0x2F3136,
                                       description=f"- You do not have that much money in your bank.\n"
                                                   f" - You wanted to withdraw \U000023e3 **{amount_conv:,}**.\n"
                                                   f" - Currently, you only have \U000023e3 **{bank_amt:,}**.")
-                return await interaction.response.send_message(embed=embed) # type: ignore
+                return await interaction.response.send_message(embed=embed) 
 
             else:
                 wallet_new = await self.update_bank_new(user, conn, +amount_conv)
@@ -3185,7 +3185,7 @@ class Economy(commands.Cog):
                 embed.add_field(name=f"Current Wallet Balance", value=f"\U000023e3 {wallet_new[0]:,}")
                 embed.add_field(name=f"Current Bank Balance", value=f"\U000023e3 {bank_new[0]:,}")
 
-                return await interaction.response.send_message(embed=embed) # type: ignore
+                return await interaction.response.send_message(embed=embed) 
 
     @app_commands.command(name='deposit', description="deposit robux to your bank account.")
     @app_commands.guilds(discord.Object(id=829053898333225010), discord.Object(id=780397076273954886))
@@ -3195,11 +3195,11 @@ class Economy(commands.Cog):
         user = interaction.user
         actual_amount = determine_exponent(robux)
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
+                return await interaction.response.send_message(embed=self.not_registered) 
             users = await self.get_bank_data_new(user, conn)
             wallet_amt = users[1]
             if isinstance(actual_amount, str):
@@ -3212,8 +3212,8 @@ class Economy(commands.Cog):
                     embed.add_field(name="Current Wallet Balance", value=f"\U000023e3 {wallet_new[0]:,}")
                     embed.add_field(name="Current Bank Balance", value=f"\U000023e3 {bank_new[0]:,}")
 
-                    return await interaction.response.send_message(embed=embed) # type: ignore
-                return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
+                    return await interaction.response.send_message(embed=embed) 
+                return await interaction.response.send_message(embed=ERR_UNREASON) 
 
             amount_conv = abs(int(actual_amount))
             if amount_conv < 5000:
@@ -3221,14 +3221,14 @@ class Economy(commands.Cog):
                                       description=f"- For performance reasons, a minimum of "
                                                   f"\U000023e3 **5,000** must be deposited.\n"
                                                   f" - You wanted to deposit \U000023e3 **{amount_conv:,}**.\n")
-                return await interaction.response.send_message(embed=embed) # type: ignore
+                return await interaction.response.send_message(embed=embed) 
 
             elif amount_conv > wallet_amt:
                 embed = discord.Embed(colour=0x2F3136,
                                       description=f"- You do not have that much money in your wallet.\n"
                                                   f" - You wanted to deposit \U000023e3 **{amount_conv:,}**.\n"
                                                   f" - Currently, you only have \U000023e3 **{wallet_amt:,}**.")
-                return await interaction.response.send_message(embed=embed) # type: ignore
+                return await interaction.response.send_message(embed=embed) 
             else:
                 wallet_new = await self.update_bank_new(user, conn, -amount_conv)
                 bank_new = await self.update_bank_new(user, conn, +amount_conv, "bank")  # \U000023e3
@@ -3238,14 +3238,14 @@ class Economy(commands.Cog):
                 embed.add_field(name="Current Wallet Balance", value=f"\U000023e3 {wallet_new[0]:,}")
                 embed.add_field(name="Current Bank Balance", value=f"\U000023e3 {bank_new[0]:,}")
 
-                return await interaction.response.send_message(embed=embed) # type: ignore
+                return await interaction.response.send_message(embed=embed) 
 
     @app_commands.command(name='leaderboard', description='rank users based on various stats.')
     @app_commands.guilds(discord.Object(id=829053898333225010), discord.Object(id=780397076273954886))
     @app_commands.checks.dynamic_cooldown(owners_nolimit)
     async def get_leaderboard(self, interaction: discord.Interaction):
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection = conn
 
             data = await conn.execute(
@@ -3280,7 +3280,7 @@ class Economy(commands.Cog):
                 icon_url=self.client.user.avatar.url)
 
         lb_view = Leaderboard(self.client)
-        await interaction.response.send_message(embed=lb, view=lb_view) # type: ignore
+        await interaction.response.send_message(embed=lb, view=lb_view) 
         lb_view.message = await interaction.original_response()
 
     @commands.guild_only()
@@ -3329,22 +3329,22 @@ class Economy(commands.Cog):
         primary_id = str(interaction.user.id)
         other_id = str(other.id)
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if other_id == primary_id:
                 embed = membed('You cannot rob yourself, everyone knows that.')
-                return await interaction.response.send_message(embed=embed) # type: ignore
+                return await interaction.response.send_message(embed=embed) 
             elif other.bot:
                 embed = membed('You are not allowed to steal from bots, back off my kind')
-                return await interaction.response.send_message(embed=embed) # type: ignore
+                return await interaction.response.send_message(embed=embed) 
             elif other_id == "992152414566232139":
                 embed = membed('You are not allowed to rob the developer of this bot.')
-                return await interaction.response.send_message(embed=embed) # type: ignore
+                return await interaction.response.send_message(embed=embed) 
             elif not (await self.can_call_out_either(interaction.user, other, conn)):
                 embed = membed(f'- Either you or {other.name} does not have an account.\n'
                                f' - </balance:1179817617435926686> to register.')
-                return await interaction.response.send_message(embed=embed) # type: ignore
+                return await interaction.response.send_message(embed=embed) 
             else:
                 prim_bal = await self.get_bank_data_new(interaction.user, conn)
                 host_bal = await self.get_bank_data_new(other, conn)
@@ -3361,7 +3361,7 @@ class Economy(commands.Cog):
                     await self.update_bank_new(other, conn, +fine)
                     conte = (f'- You were caught stealing now you paid {other.name} \U000023e3 **{fine:,}**.\n'
                              f'- **{prcf}**% of your money was handed over to the victim.')
-                    return await interaction.response.send_message(embed=membed(conte)) # type: ignore
+                    return await interaction.response.send_message(embed=membed(conte)) 
                 else:
                     steal_amount = randint(1, host_bal[1])
                     await self.update_bank_new(interaction.user, conn, +steal_amount)
@@ -3369,7 +3369,7 @@ class Economy(commands.Cog):
 
                     prcf = round((steal_amount / host_bal[1]) * 100, ndigits=1)
 
-                    return await interaction.response.send_message( # type: ignore
+                    return await interaction.response.send_message( 
                         embed=membed(f"- You managed to steal \U000023e3 **{steal_amount:,}** from {other.name}.\n"
                                      f"- You took a dandy **{prcf}**% of {other.name}'s `wallet` balance."),
                         delete_after=10.0)
@@ -3377,9 +3377,9 @@ class Economy(commands.Cog):
     @rob.command(name='casino', description='rob a casino vault.')
     async def rob_the_casino(self, interaction: discord.Interaction):
 
-        await interaction.response.defer() # type: ignore
+        await interaction.response.defer() 
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
@@ -3495,33 +3495,33 @@ class Economy(commands.Cog):
     async def coinflip(self, interaction: discord.Interaction, bet_on: str, amount: int):
         user = interaction.user
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
 
             amount = determine_exponent(str(amount))
 
             bet_on = "heads" if "h" in bet_on.lower() else "tails"
             if not 5000 <= amount <= 100_000_000:
-                return await interaction.response.send_message(  # type: ignore
+                return await interaction.response.send_message(  
                     embed=membed(f"*As per-policy*, the minimum bet is {CURRENCY}**5,000**, the maximum is "
                                  f"{CURRENCY}**200,000,000**."))
 
             conn: asqlite_Connection
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
+                return await interaction.response.send_message(embed=self.not_registered) 
             wallet_amt = await self.get_wallet_data_only(user, conn)
             if wallet_amt < amount:
-                return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
+                return await interaction.response.send_message(embed=ERR_UNREASON) 
 
             coin = ["heads", "tails"]
             result = choice(coin)
 
             if result != bet_on:
                 await self.update_bank_new(user, conn, -amount)
-                return await interaction.response.send_message( # type: ignore
+                return await interaction.response.send_message( 
                     embed=membed(f"You got {result}, meaning you lost \U000023e3 **{amount:,}**."))
 
             await self.update_bank_new(user, conn, +amount)
-            return await interaction.response.send_message(embed=membed(f"You got {result}, meaning you won \U000023e3 " # type: ignore
+            return await interaction.response.send_message(embed=membed(f"You got {result}, meaning you won \U000023e3 " 
                                                                         f"**{amount:,}**."))
 
     @app_commands.command(name="blackjack",
@@ -3533,8 +3533,8 @@ class Economy(commands.Cog):
     async def play_blackjack(self, interaction: discord.Interaction, bet_amount: str):
 
         # ------ Check the user is registered or already has an ongoing game ---------
-        if len(self.client.games) >= 2: # type: ignore
-            return await interaction.response.send_message( # type: ignore
+        if len(self.client.games) >= 2: 
+            return await interaction.response.send_message( 
                 embed=membed(
                     "- The maximum consecutive blackjack games being held has been reached.\n"
                     "- To prevent server overload, you cannot start a game until the current games "
@@ -3543,14 +3543,14 @@ class Economy(commands.Cog):
                 )
             )
 
-        if self.client.games.setdefault(interaction.user.id, None) is not None: # type: ignore
-            return await interaction.response.send_message( # type: ignore
+        if self.client.games.setdefault(interaction.user.id, None) is not None: 
+            return await interaction.response.send_message( 
                 "You already have an ongoing game taking place.")
 
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             conn: asqlite_Connection
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
+                return await interaction.response.send_message(embed=self.not_registered) 
 
         # ----------------- Game setup ---------------------------------
 
@@ -3579,38 +3579,38 @@ class Economy(commands.Cog):
                 else:
                     namount = min(50_000_000, wallet_amt)
             else:
-                return await interaction.response.send_message(embed=ERR_UNREASON)  # type: ignore
+                return await interaction.response.send_message(embed=ERR_UNREASON)  
 
         # -------------------- Check to see if user has sufficient balance --------------------------
 
         if has_keycard:
             if not (500_000 <= namount <= 100_000_000):
-                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=( # type: ignore
+                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=( 
                     f'## You did not meet the blackjack criteria.\n'
                     f'- You wanted to bet {CURRENCY}**{namount:,}**\n'
                     f' - A minimum bet of {CURRENCY}**500,000** must be made\n'
                     f' - A maximum bet of {CURRENCY}**100,000,000** can only be made.'
-                )))  # type: ignore
+                )))  
             elif namount > wallet_amt:
-                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=( # type: ignore
+                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=( 
                     f'Cannot perform this action.\n'
                     f'You only have {CURRENCY}**{wallet_amt:,}**.\n'
                     f'You\'ll need {CURRENCY}**{namount - wallet_amt:,}** more in your wallet first.'
-                )))  # type: ignore
+                )))  
         else:
             if not (1000000 <= namount <= 50_000_000):
-                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=( # type: ignore
+                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=( 
                     f'## You did not meet the blackjack criteria.\n'
                     f'- You wanted to bet {CURRENCY}**{namount:,}**\n'
                     f' - A minimum bet of {CURRENCY}**1,000,000** must be made.\n'
                     f' - A maximum bet of {CURRENCY}**50,000,000** can only be made.'
-                )))  # type: ignore
+                )))  
             elif namount > wallet_amt:
-                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=( # type: ignore
+                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=( 
                     f"## Cannot perform this action.\n"
                     f"You only have {CURRENCY}**{wallet_amt:,}**.\n"
                     f"You'll need {CURRENCY}**{namount - wallet_amt:,}** more in your wallet first."
-                )))  # type: ignore
+                )))  
 
         # ------------ In the case where the user already won --------------
         if self.calculate_hand(player_hand) == 21:
@@ -3641,7 +3641,7 @@ class Economy(commands.Cog):
             embed.add_field(name=f"{interaction.guild.me.name} (Dealer)",
                             value=f"**Cards** - {' '.join(d_fver_d)}\n"
                                   f"**Total** - {sum(dealer_hand)}")
-            return await interaction.response.send_message(embed=embed) # type: ignore
+            return await interaction.response.send_message(embed=embed) 
 
         shallow_pv = []
         shallow_dv = []
@@ -3654,7 +3654,7 @@ class Economy(commands.Cog):
             remade = display_user_friendly_card_format(number)
             shallow_dv.append(remade)
 
-        self.client.games[interaction.user.id] = (deck, player_hand, dealer_hand, shallow_dv, shallow_pv, namount) # type: ignore
+        self.client.games[interaction.user.id] = (deck, player_hand, dealer_hand, shallow_dv, shallow_pv, namount) 
 
 
         start = discord.Embed(colour=0x2B2D31,
@@ -3670,7 +3670,7 @@ class Economy(commands.Cog):
         start.set_author(icon_url=interaction.user.display_avatar.url, name=f"{interaction.user.name}'s blackjack game")
         start.set_footer(text="K, Q, J = 10  |  A = 1 or 11")
         my_view = BlackjackUi(interaction, self.client)
-        await interaction.response.send_message( # type: ignore
+        await interaction.response.send_message( 
             content="What do you want to do?\nPress **Hit** to to request an additional card, **Stand** to finalize "
                     "your deck or **Forfeit** to end your hand prematurely, sacrificing half of your original bet.",
             embed=start, view=my_view)
@@ -3688,9 +3688,9 @@ class Economy(commands.Cog):
         """Bet your robux on a gamble to win or lose robux."""
 
         # --------------- Contains checks before betting i.e. has keycard, meets bet constraints. -------------
-        async with self.client.pool_connection.acquire() as conn: # type: ignore
+        async with self.client.pool_connection.acquire() as conn: 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
+                return await interaction.response.send_message(embed=self.not_registered) 
             conn: asqlite_Connection
 
             data = await conn.execute(f"SELECT pmulti, wallet, betw, betl FROM `{BANK_TABLE_NAME}` WHERE userID = ?",
@@ -3710,7 +3710,7 @@ class Economy(commands.Cog):
                     else:
                         amount = min(50_000_000, wallet_amt)
                 else:
-                    return await interaction.response.send_message(embed=ERR_UNREASON)  # type: ignore
+                    return await interaction.response.send_message(embed=ERR_UNREASON)  
 
             if has_keycard:
                 if (amount > 100000000) or (amount < 100000):
@@ -3720,13 +3720,13 @@ class Economy(commands.Cog):
                                                                      f'be made\n'
                                                                      f' - A maximum bet of {CURRENCY}**100,000,000** '
                                                                      f'can only be made.')
-                    return await interaction.response.send_message(embed=err) # type: ignore
+                    return await interaction.response.send_message(embed=err) 
                 elif amount > wallet_amt:
                     err = discord.Embed(colour=0x2F3136, description=f'Cannot perform this action, '
                                                                      f'you only have {CURRENCY}**{wallet_amt:,}**.\n'
                                                                      f'You\'ll need {CURRENCY}**{amount - wallet_amt:,}**'
                                                                      f' more in your wallet first.')
-                    return await interaction.response.send_message(embed=err) # type: ignore
+                    return await interaction.response.send_message(embed=err) 
             else:
                 if (amount > 50000000) or (amount < 500000):
                     err = discord.Embed(colour=0x2F3136, description=f'## You did not meet the bet criteria:\n'
@@ -3738,13 +3738,13 @@ class Economy(commands.Cog):
                                                                      f'can only be made (this can increase when you '
                                                                      f'acquire a <:lanyard:1165935243140796487> '
                                                                      f'Keycard).')
-                    return await interaction.response.send_message(embed=err) # type: ignore
+                    return await interaction.response.send_message(embed=err) 
                 elif amount > wallet_amt:
                     err = discord.Embed(colour=0x2F3136, description=f'Cannot perform this action, '
                                                                      f'you only have {CURRENCY}**{wallet_amt:,}**.\n'
                                                                      f'You\'ll need {CURRENCY}**{amount - wallet_amt:,}**'
                                                                      f' more in your wallet first.')
-                    return await interaction.response.send_message(embed=err) # type: ignore
+                    return await interaction.response.send_message(embed=err) 
 
             # --------------------------------------------------------
             smulti = SERVER_MULTIPLIERS.setdefault(interaction.guild.id, 0) + pmulti
@@ -3800,7 +3800,7 @@ class Economy(commands.Cog):
 
             embed.add_field(name=interaction.user.name, value=f"Rolled `{your_choice[0]}` {''.join(badges)}")
             embed.add_field(name=self.client.user.name, value=f"Rolled `{bot_choice[0]}`")
-            await interaction.response.send_message(embed=embed)  # type: ignore
+            await interaction.response.send_message(embed=embed)  
 
             await self.raise_pmulti_warning(interaction, pmulti)
 

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -410,7 +410,7 @@ class ConfirmDeny(discord.ui.View):
         for item in self.children:
             item.disabled = True
         if self.timed_out:
-            await self.msg.edit(embed=membed("Timed out waiting for a response.\n" 
+            await self.msg.edit(embed=membed("Timed out waiting for a response.\n" # type: ignore
                                              "The operation was cancelled."), view=None)
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
@@ -420,7 +420,7 @@ class ConfirmDeny(discord.ui.View):
         else:
             emb = membed(
                 f"{self.interaction.user.mention} can only give consent to perform this action.")
-            await interaction.response.send_message(embed=emb, ephemeral=True) 
+            await interaction.response.send_message(embed=emb, ephemeral=True) # type: ignore
             return False
 
     @discord.ui.button(label='Confirm', style=discord.ButtonStyle.gray)
@@ -431,7 +431,7 @@ class ConfirmDeny(discord.ui.View):
             item.disabled = True
 
         tables_to_delete = [BANK_TABLE_NAME, INV_TABLE_NAME, COOLDOWN_TABLE_NAME, SLAY_TABLE_NAME]
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
             for table in tables_to_delete:
                 await conn.execute(f"DELETE FROM `{table}` WHERE userID = ?", (self.member.id,))
@@ -474,11 +474,11 @@ class BlackjackUi(discord.ui.View):
         await self.disable_all_items()
         if not self.finished:
 
-            namount = self.client.games[self.interaction.user.id][-1]  
+            namount = self.client.games[self.interaction.user.id][-1]  # type: ignore
             namount = floor(((130 / 100) * namount))
-            del self.client.games[self.interaction.user.id]  
+            del self.client.games[self.interaction.user.id]  # type: ignore
 
-            async with self.client.pool_connection.acquire() as conn:  
+            async with self.client.pool_connection.acquire() as conn:  # type: ignore
                 conn: asqlite_Connection
 
                 await Economy.update_bank_new(self.interaction.guild.me, conn, namount)
@@ -495,7 +495,7 @@ class BlackjackUi(discord.ui.View):
             losse.set_author(name=f"{self.interaction.user.name}'s timed-out blackjack game",
                              icon_url=self.interaction.user.display_avatar.url)
 
-            return await self.message.edit( 
+            return await self.message.edit( # type: ignore
                 content=None, embed=losse, view=self)
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
@@ -506,29 +506,29 @@ class BlackjackUi(discord.ui.View):
                 description=f"This game is being held under {self.interaction.user.name}'s name. Not yours.",
                 color=0x2F3136
             )
-            await interaction.response.send_message(embed=emb, ephemeral=True) 
+            await interaction.response.send_message(embed=emb, ephemeral=True) # type: ignore
             return False
 
     @discord.ui.button(label='Hit', style=discord.ButtonStyle.blurple)
     async def hit_bj(self, interaction: discord.Interaction, button: discord.ui.Button):
 
-        namount = self.client.games[interaction.user.id][-1] 
-        deck = self.client.games[interaction.user.id][0]  
-        player_hand = self.client.games[interaction.user.id][1]  
+        namount = self.client.games[interaction.user.id][-1] # type: ignore
+        deck = self.client.games[interaction.user.id][0]  # type: ignore
+        player_hand = self.client.games[interaction.user.id][1]  # type: ignore
 
         player_hand.append(deck.pop())
-        self.client.games[interaction.user.id][-2].append(display_user_friendly_card_format(player_hand[-1])) 
+        self.client.games[interaction.user.id][-2].append(display_user_friendly_card_format(player_hand[-1])) # type: ignore
         player_sum = sum(player_hand)
 
         if player_sum > 21:
 
             await self.disable_all_items()
             self.finished = True
-            dealer_hand = self.client.games[interaction.user.id][2] 
-            d_fver_p = [num for num in self.client.games[interaction.user.id][-2]] 
-            d_fver_d = [num for num in self.client.games[interaction.user.id][-3]] 
-            del self.client.games[interaction.user.id] 
-            async with self.client.pool_connection.acquire() as conn:  
+            dealer_hand = self.client.games[interaction.user.id][2] # type: ignore
+            d_fver_p = [num for num in self.client.games[interaction.user.id][-2]] # type: ignore
+            d_fver_d = [num for num in self.client.games[interaction.user.id][-3]] # type: ignore
+            del self.client.games[interaction.user.id] # type: ignore
+            async with self.client.pool_connection.acquire() as conn:  # type: ignore
                 conn: asqlite_Connection
 
                 await Economy.update_bank_new(interaction.user, conn, namount, "bjla")
@@ -552,20 +552,20 @@ class BlackjackUi(discord.ui.View):
 
                 embed.set_author(name=f"{interaction.user.name}'s losing blackjack game",
                                  icon_url=interaction.user.display_avatar.url)
-                await interaction.response.edit_message(content=None, embed=embed, view=None) 
+                await interaction.response.edit_message(content=None, embed=embed, view=None) # type: ignore
 
         elif sum(player_hand) == 21:
 
             self.finished = True
             await self.disable_all_items()
 
-            dealer_hand = self.client.games[interaction.user.id][2] 
-            d_fver_p = [num for num in self.client.games[interaction.user.id][-2]] 
-            d_fver_d = [num for num in self.client.games[interaction.user.id][-3]] 
+            dealer_hand = self.client.games[interaction.user.id][2] # type: ignore
+            d_fver_p = [num for num in self.client.games[interaction.user.id][-2]] # type: ignore
+            d_fver_d = [num for num in self.client.games[interaction.user.id][-3]] # type: ignore
 
-            del self.client.games[interaction.user.id] 
+            del self.client.games[interaction.user.id] # type: ignore
 
-            async with self.client.pool_connection.acquire() as conn:  
+            async with self.client.pool_connection.acquire() as conn:  # type: ignore
                 conn: asqlite_Connection
 
                 bj_lose = await conn.execute('SELECT bjl FROM bank WHERE userID = ?', (interaction.user.id,))
@@ -592,13 +592,13 @@ class BlackjackUi(discord.ui.View):
                                                                           f"**Total** - `{sum(dealer_hand)}`")
                 win.set_author(name=f"{interaction.user.name}'s winning blackjack game",
                                icon_url=interaction.user.display_avatar.url)
-                await interaction.response.edit_message(content=None, embed=win, view=None) 
+                await interaction.response.edit_message(content=None, embed=win, view=None) # type: ignore
 
         else:
 
-            player_hand = self.client.games[interaction.user.id][1] 
-            d_fver_p = [number for number in self.client.games[interaction.user.id][-2]] 
-            necessary_show = self.client.games[interaction.user.id][-3][0] 
+            player_hand = self.client.games[interaction.user.id][1] # type: ignore
+            d_fver_p = [number for number in self.client.games[interaction.user.id][-2]] # type: ignore
+            necessary_show = self.client.games[interaction.user.id][-3][0] # type: ignore
             ts = sum(player_hand)
 
             prg = discord.Embed(colour=0x2B2D31,
@@ -610,7 +610,7 @@ class BlackjackUi(discord.ui.View):
 
             prg.set_footer(text="K, Q, J = 10  |  A = 1 or 11")
             prg.set_author(icon_url=interaction.user.display_avatar.url, name=f"{interaction.user.name}'s blackjack game")
-            await interaction.response.edit_message( 
+            await interaction.response.edit_message( # type: ignore
                 content="Press **Hit** to hit, **Stand** to finalize your deck or "
                         "**Forfeit** to end your hand prematurely.", embed=prg, view=self)
 
@@ -619,10 +619,10 @@ class BlackjackUi(discord.ui.View):
 
         await self.disable_all_items()
 
-        deck = self.client.games[interaction.user.id][0] 
-        player_hand = self.client.games[interaction.user.id][1] 
-        dealer_hand = self.client.games[interaction.user.id][2] 
-        namount = self.client.games[interaction.user.id][-1] 
+        deck = self.client.games[interaction.user.id][0] # type: ignore
+        player_hand = self.client.games[interaction.user.id][1] # type: ignore
+        dealer_hand = self.client.games[interaction.user.id][2] # type: ignore
+        namount = self.client.games[interaction.user.id][-1] # type: ignore
 
         dealer_total = calculate_hand(dealer_hand)
 
@@ -631,18 +631,18 @@ class BlackjackUi(discord.ui.View):
 
             dealer_hand.append(popped)
 
-            self.client.games[interaction.user.id][-3].append(display_user_friendly_card_format(popped)) 
+            self.client.games[interaction.user.id][-3].append(display_user_friendly_card_format(popped)) # type: ignore
 
             dealer_total = calculate_hand(dealer_hand)
 
         player_sum = sum(player_hand)
-        d_fver_p = self.client.games[interaction.user.id][-2] 
-        d_fver_d = self.client.games[interaction.user.id][-3] 
-        del self.client.games[interaction.user.id] 
+        d_fver_p = self.client.games[interaction.user.id][-2] # type: ignore
+        d_fver_d = self.client.games[interaction.user.id][-3] # type: ignore
+        del self.client.games[interaction.user.id] # type: ignore
 
         if dealer_total > 21:
             self.finished = True
-            async with self.client.pool_connection.acquire() as conn:  
+            async with self.client.pool_connection.acquire() as conn:  # type: ignore
                 conn: asqlite_Connection
 
                 bj_lose = await conn.execute('SELECT bjl FROM bank WHERE userID = ?', (interaction.user.id,))
@@ -669,11 +669,11 @@ class BlackjackUi(discord.ui.View):
                                                                       f"**Total** - `{dealer_total}`")
 
             win.set_author(icon_url=interaction.user.display_avatar.url, name=f"{interaction.user.name}'s winning blackjack game")
-            await interaction.response.edit_message(content=None, embed=win, view=None) 
+            await interaction.response.edit_message(content=None, embed=win, view=None) # type: ignore
 
         elif dealer_total > sum(player_hand):
             self.finished = True
-            async with self.client.pool_connection.acquire() as conn:  
+            async with self.client.pool_connection.acquire() as conn:  # type: ignore
                 conn: asqlite_Connection
 
                 bj_win = await conn.execute('SELECT bjw FROM bank WHERE userID = ?', (interaction.user.id,))
@@ -696,11 +696,11 @@ class BlackjackUi(discord.ui.View):
             loser.add_field(name=f"{interaction.guild.me.name} (Dealer)", value=f"**Cards** - {' '.join(d_fver_d)}\n"
                                                                         f"**Total** - `{dealer_total}`")
             loser.set_author(icon_url=interaction.user.display_avatar.url, name=f"{interaction.user.name}'s losing blackjack game")
-            await interaction.response.edit_message(content=None, embed=loser, view=None) 
+            await interaction.response.edit_message(content=None, embed=loser, view=None) # type: ignore
 
         elif dealer_total < sum(player_hand):
             self.finished = True
-            async with self.client.pool_connection.acquire() as conn:  
+            async with self.client.pool_connection.acquire() as conn:  # type: ignore
                 conn: asqlite_Connection
 
                 bj_lose = await conn.execute('SELECT bjl FROM bank WHERE userID = ?', (interaction.user.id,))
@@ -725,10 +725,10 @@ class BlackjackUi(discord.ui.View):
             win.add_field(name=f"{interaction.guild.me.name} (Dealer)", value=f"**Cards** - {' '.join(d_fver_d)}\n"
                                                                       f"**Total** - `{dealer_total}`")
             win.set_author(icon_url=interaction.user.display_avatar.url, name=f"{interaction.user.name}'s winning blackjack game")
-            await interaction.response.edit_message(content=None, embed=win, view=None) 
+            await interaction.response.edit_message(content=None, embed=win, view=None) # type: ignore
         else:
             self.finished = True
-            async with self.client.pool_connection.acquire() as conn:  
+            async with self.client.pool_connection.acquire() as conn:  # type: ignore
                 conn: asqlite_Connection
                 wallet_amt = await Economy.get_wallet_data_only(interaction.user, conn)
             tie = discord.Embed(colour=discord.Colour.yellow(),
@@ -739,22 +739,22 @@ class BlackjackUi(discord.ui.View):
             tie.add_field(name=f"{interaction.guild.me.name} (Dealer)", value=f"**Cards** - {' '.join(d_fver_d)}\n"
                                                                       f"**Total** - `{dealer_total}`")
             tie.set_author(icon_url=interaction.user.display_avatar.url, name=f"{interaction.user.name}'s blackjack game")
-            await interaction.response.edit_message(content=None, embed=tie, view=None) 
+            await interaction.response.edit_message(content=None, embed=tie, view=None) # type: ignore
 
     @discord.ui.button(label='Forfeit', style=discord.ButtonStyle.blurple)
     async def forfeit_bj(self, interaction: discord.Interaction, button: discord.ui.Button):
         self.finished = True
         await self.disable_all_items()
-        namount = self.client.games[interaction.user.id][-1] 
+        namount = self.client.games[interaction.user.id][-1] # type: ignore
         namount = namount // 2
-        dealer_total = sum(self.client.games[interaction.user.id][2]) 
-        player_sum = sum(self.client.games[interaction.user.id][1]) 
-        d_fver_p = self.client.games[interaction.user.id][-2] 
-        d_fver_d = self.client.games[interaction.user.id][-3] 
+        dealer_total = sum(self.client.games[interaction.user.id][2]) # type: ignore
+        player_sum = sum(self.client.games[interaction.user.id][1]) # type: ignore
+        d_fver_p = self.client.games[interaction.user.id][-2] # type: ignore
+        d_fver_d = self.client.games[interaction.user.id][-3] # type: ignore
 
-        del self.client.games[interaction.user.id] 
+        del self.client.games[interaction.user.id] # type: ignore
 
-        async with self.client.pool_connection.acquire() as conn:  
+        async with self.client.pool_connection.acquire() as conn:  # type: ignore
             conn: asqlite_Connection
 
             bj_win = await conn.execute('SELECT bjw FROM bank WHERE userID = ?', (interaction.user.id,))
@@ -778,7 +778,7 @@ class BlackjackUi(discord.ui.View):
         loser.set_author(icon_url=interaction.user.display_avatar.url,
                          name=f"{interaction.user.name}'s losing blackjack game")
 
-        await interaction.response.edit_message(content=None, embed=loser, view=None) 
+        await interaction.response.edit_message(content=None, embed=loser, view=None) # type: ignore
 
 class HighLow(discord.ui.View):
     """View for the Highlow command and its associated functions."""
@@ -803,14 +803,14 @@ class HighLow(discord.ui.View):
         if interaction.user == self.interaction.user:
             return True
 
-        await interaction.response.send_message( 
+        await interaction.response.send_message( # type: ignore
             content=f"This is not your highlow game {interaction.user.display_name}! Make one yourself.",
             ephemeral=True, delete_after=5.5)
         return False
 
     @discord.ui.button(label='Lower', style=discord.ButtonStyle.blurple)
     async def low(self, interaction: discord.Interaction, button: discord.ui.Button):
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if self.true_value < self.hint_provided:
@@ -829,7 +829,7 @@ class HighLow(discord.ui.View):
                                     colour=discord.Color.brand_green())
                 win.set_author(name=f"{interaction.user.name}'s winning high-low game",
                                icon_url=interaction.user.display_avatar.url)
-                await interaction.response.edit_message(embed=win, view=self) 
+                await interaction.response.edit_message(embed=win, view=self) # type: ignore
             else:
                 new_amount = await Economy.update_bank_new(interaction.user, conn, -self.their_bet)
                 await self.make_clicked_blurple_only(button)
@@ -841,11 +841,11 @@ class HighLow(discord.ui.View):
                                      colour=discord.Color.brand_red())
                 lose.set_author(name=f"{interaction.user.name}'s losing high-low game",
                                 icon_url=interaction.user.display_avatar.url)
-                await interaction.response.edit_message(embed=lose, view=self) 
+                await interaction.response.edit_message(embed=lose, view=self) # type: ignore
 
     @discord.ui.button(label='JACKPOT!', style=discord.ButtonStyle.blurple)
     async def jackpot(self, interaction: discord.Interaction, button: discord.ui.Button):
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if self.hint_provided == self.true_value:
@@ -864,7 +864,7 @@ class HighLow(discord.ui.View):
                                     colour=discord.Color.brand_green())
                 win.set_author(name=f"{interaction.user.name}'s winning high-low game",
                                icon_url=interaction.user.display_avatar.url)
-                await interaction.response.edit_message(embed=win, view=self) 
+                await interaction.response.edit_message(embed=win, view=self) # type: ignore
             else:
                 new_bal = await Economy.update_bank_new(interaction.user, conn, -self.their_bet)
                 await self.make_clicked_blurple_only(button)
@@ -877,11 +877,11 @@ class HighLow(discord.ui.View):
                 lose.set_author(name=f"{interaction.user.name}'s losing high-low game",
                                 icon_url=interaction.user.display_avatar.url)
 
-                await interaction.response.edit_message(embed=lose, view=self) 
+                await interaction.response.edit_message(embed=lose, view=self) # type: ignore
 
     @discord.ui.button(label='Higher', style=discord.ButtonStyle.blurple)
     async def high(self, interaction: discord.Interaction, button: discord.ui.Button):
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if self.true_value > self.hint_provided:
@@ -900,7 +900,7 @@ class HighLow(discord.ui.View):
                                     colour=discord.Color.brand_green())
                 win.set_author(name=f"{interaction.user.name}'s winning high-low game",
                                icon_url=interaction.user.display_avatar.url)
-                await interaction.response.edit_message(embed=win, view=self) 
+                await interaction.response.edit_message(embed=win, view=self) # type: ignore
             else:
                 new_bal = await Economy.update_bank_new(interaction.user, conn, -self.their_bet)
                 await self.make_clicked_blurple_only(button)
@@ -912,7 +912,7 @@ class HighLow(discord.ui.View):
                                      colour=discord.Color.brand_red())
                 lose.set_author(name=f"{interaction.user.name}'s losing high-low game",
                                 icon_url=interaction.user.display_avatar.url)
-                await interaction.response.edit_message(embed=lose, view=self) 
+                await interaction.response.edit_message(embed=lose, view=self) # type: ignore
 
 
 class UpdateInfo(discord.ui.Modal, title='Update your Profile'):
@@ -928,11 +928,11 @@ class UpdateInfo(discord.ui.Modal, title='Update your Profile'):
         if self.bio.value == "delete":
             res = modify_profile("delete", f"{interaction.user.id} bio", "placeholder")
             if res == 0:
-                return await interaction.response.send_message(  
+                return await interaction.response.send_message(  # type: ignore
                     embed=membed("<:warning_nr:1195732155544911882> You don't have a bio yet. Add one first."))
 
             else:
-                return await interaction.response.send_message(  
+                return await interaction.response.send_message(  # type: ignore
                     embed=membed(f'## <:trim:1195732275283894292> Your bio has been removed.\n'
                                  f'The changes have taken effect immediately.'))
 
@@ -940,7 +940,7 @@ class UpdateInfo(discord.ui.Modal, title='Update your Profile'):
         phrases = "updated your" if get_profile_key_value(f"{interaction.user.id} bio") is not None else "created a new"
         modify_profile("update", f"{interaction.user.id} bio", self.bio.value)
 
-        return await interaction.response.send_message( 
+        return await interaction.response.send_message( # type: ignore
             embed=membed(
                 f"## <:overwrite:1195729262729240666> Successfully {phrases} bio.\n"
                 f"It is now:\n"
@@ -949,7 +949,7 @@ class UpdateInfo(discord.ui.Modal, title='Update your Profile'):
 
     async def on_error(self, interaction: discord.Interaction, error):
 
-        return await interaction.response.send_message( 
+        return await interaction.response.send_message( # type: ignore
             embed=membed(f"Something went wrong.\n\n> {error.__cause__}"))
 
 
@@ -976,7 +976,7 @@ class DropdownLB(discord.ui.Select):
 
         if chosen_choice == 'Bank + Wallet':
 
-            async with self.client.pool_connection.acquire() as conn: 
+            async with self.client.pool_connection.acquire() as conn: # type: ignore
                 conn: asqlite_Connection = conn
 
                 data = await conn.execute(
@@ -1009,11 +1009,11 @@ class DropdownLB(discord.ui.Select):
                     text=f"Ranked globally",
                     icon_url=self.client.user.avatar.url)
 
-            await interaction.response.edit_message(content=None, embed=lb, view=self.view) 
+            await interaction.response.edit_message(content=None, embed=lb, view=self.view) # type: ignore
 
         elif chosen_choice == 'Wallet':
 
-            async with self.client.pool_connection.acquire() as conn: 
+            async with self.client.pool_connection.acquire() as conn: # type: ignore
                 conn: asqlite_Connection = conn
 
                 data = await conn.execute(
@@ -1045,10 +1045,10 @@ class DropdownLB(discord.ui.Select):
                     text=f"Ranked globally",
                     icon_url=self.client.user.avatar.url)
 
-            await interaction.response.edit_message(content=None, embed=lb, view=self.view) 
+            await interaction.response.edit_message(content=None, embed=lb, view=self.view) # type: ignore
 
         elif chosen_choice == 'Bank':
-            async with self.client.pool_connection.acquire() as conn: 
+            async with self.client.pool_connection.acquire() as conn: # type: ignore
                 conn: asqlite_Connection = conn
 
                 data = await conn.execute(
@@ -1080,10 +1080,10 @@ class DropdownLB(discord.ui.Select):
                     text=f"Ranked globally",
                     icon_url=self.client.user.avatar.url)
 
-            await interaction.response.edit_message(content=None, embed=lb, view=self.view) 
+            await interaction.response.edit_message(content=None, embed=lb, view=self.view) # type: ignore
 
         else:
-            async with self.client.pool_connection.acquire() as conn: 
+            async with self.client.pool_connection.acquire() as conn: # type: ignore
                 conn: asqlite_Connection = conn
 
                 data = await conn.execute(
@@ -1116,7 +1116,7 @@ class DropdownLB(discord.ui.Select):
                     text=f"Ranked globally",
                     icon_url=self.client.user.avatar.url)
 
-            await interaction.response.edit_message(content=None, embed=lb, view=self.view) 
+            await interaction.response.edit_message(content=None, embed=lb, view=self.view) # type: ignore
 
 class Leaderboard(discord.ui.View):
     def __init__(self, client: commands.Bot):
@@ -1128,7 +1128,7 @@ class Leaderboard(discord.ui.View):
         for item in self.children:
             item.disabled = True
 
-        await self.message.edit(view=self) 
+        await self.message.edit(view=self) # type: ignore
 
 
 class Economy(commands.Cog):
@@ -1160,7 +1160,7 @@ class Economy(commands.Cog):
 
     async def fetch_tatsu_profile(self, user_id: int):
         """Get tatsu data associated with a given user."""
-        repeat = ApiWrapper(key=self.client.TATSU_API_KEY)  
+        repeat = ApiWrapper(key=self.client.TATSU_API_KEY)  # type: ignore
         repeat = await repeat.get_profile(user_id)
         return repeat
 
@@ -1168,7 +1168,7 @@ class Economy(commands.Cog):
         if their_pmulti in {"0", 0}:
             hook_id = get_profile_key_value(f"{interaction.channel.id} webhook")
             if hook_id is None:
-                async with self.client.session.get("https://i.imgur.com/3aMsyXI.jpg") as resp:  
+                async with self.client.session.get("https://i.imgur.com/3aMsyXI.jpg") as resp:  # type: ignore
                     avatar_data = await resp.read()
                 hook = await interaction.channel.create_webhook(name='Notify', avatar=avatar_data)
                 modify_profile("update", f"{interaction.channel.id} webhook", hook.id)
@@ -1182,7 +1182,7 @@ class Economy(commands.Cog):
                                custom_text: str):
         hook_id = get_profile_key_value(f"{interaction.channel.id} webhook")
         if hook_id is None:
-            async with self.client.session.get("https://i.imgur.com/3aMsyXI.jpg") as resp:  
+            async with self.client.session.get("https://i.imgur.com/3aMsyXI.jpg") as resp:  # type: ignore
                 avatar_data = await resp.read()
             hook = await interaction.channel.create_webhook(name='Notify', avatar=avatar_data)
             modify_profile("update", f"{interaction.channel.id} webhook", hook.id)
@@ -1500,7 +1500,7 @@ class Economy(commands.Cog):
 
     @commands.Cog.listener()
     async def on_app_command_completion(self, interaction: discord.Interaction, command):
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
             if await self.can_call_out(interaction.user, conn):
                 return
@@ -1519,14 +1519,14 @@ class Economy(commands.Cog):
     @app_commands.checks.dynamic_cooldown(owners_nolimit)
     async def my_multi(self, interaction: discord.Interaction, user_name: Optional[discord.Member]):
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if user_name is None:
                 user_name = interaction.user
 
             if await Economy.can_call_out(user_name, conn):
-                return await interaction.response.send_message(embed=NOT_REGISTERED) 
+                return await interaction.response.send_message(embed=NOT_REGISTERED) # type: ignore
             their_multi = await Economy.get_pmulti_data_only(user_name, conn)
 
             if their_multi[0] == 0 and (user_name.id == interaction.user.id):
@@ -1563,7 +1563,7 @@ class Economy(commands.Cog):
                 multi_own.set_author(name=f'Viewing {user_name.name}\'s multipliers',
                                      icon_url=user_name.display_avatar.url)
 
-            await interaction.response.send_message(embed=multi_own) 
+            await interaction.response.send_message(embed=multi_own) # type: ignore
 
     share = app_commands.Group(name='share', description='share different assets with others.',
                                guild_only=True, guild_ids=APP_GUILDS_ID)
@@ -1576,11 +1576,11 @@ class Economy(commands.Cog):
     async def give_robux(self, interaction: discord.Interaction, other: discord.Member, amount: str):
         inter_user = interaction.user
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if not (await self.can_call_out_either(inter_user, other, conn)):
-                return await interaction.response.send_message(embed=NOT_REGISTERED) 
+                return await interaction.response.send_message(embed=NOT_REGISTERED) # type: ignore
             else:
                 real_amount = determine_exponent(amount)
                 wallet_amt_host = await Economy.get_wallet_data_only(inter_user, conn)
@@ -1589,14 +1589,14 @@ class Economy(commands.Cog):
                     if real_amount.lower() == 'all' or real_amount.lower() == 'max':
                         real_amount = wallet_amt_host
                     else:
-                        return await interaction.response.send_message(embed=ERR_UNREASON) 
+                        return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
                     host_amt = await self.update_bank_new(inter_user, conn, -int(real_amount))
                     recp_amt = await self.update_bank_new(other, conn, int(real_amount))
                 else:
                     if real_amount == 0:
-                        return await interaction.response.send_message(embed=ERR_UNREASON) 
+                        return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
                     elif real_amount > wallet_amt_host:
-                        return await interaction.response.send_message(embed=ERR_UNREASON) 
+                        return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
                     else:
                         host_amt = await self.update_bank_new(inter_user, conn, -int(real_amount))
                         recp_amt = await self.update_bank_new(other, conn, int(real_amount))
@@ -1610,7 +1610,7 @@ class Economy(commands.Cog):
                 embed.set_thumbnail(url="https://i.imgur.com/RxQuE8T.png")
                 embed.set_author(name=f'Transaction made by {inter_user.name}',
                                  icon_url=inter_user.display_avatar.url)
-                return await interaction.response.send_message(embed=embed) 
+                return await interaction.response.send_message(embed=embed) # type: ignore
 
     @share.command(name='items', description='share items with another user.')
     @app_commands.describe(item_name='the name of the item you want to share.',
@@ -1621,18 +1621,18 @@ class Economy(commands.Cog):
                          amount: Literal[1, 2, 3, 4, 5], username: discord.Member):
         primm = interaction.user
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
             item_name = item_name.replace(" ", "_")
             if not(await self.can_call_out_either(primm, username, conn)):
                 embed = discord.Embed(description=f'Either you or {username.name} does not have an account.\n'
                                                   f'</balance:1179817617435926686> to register.',
                                       colour=0x2F3136)
-                return await interaction.response.send_message(embed=embed) 
+                return await interaction.response.send_message(embed=embed) # type: ignore
             else:
                 quantity = await self.update_inv_new(primm, 0, item_name, conn)
                 if amount > quantity[0]:
-                    return await interaction.response.send_message(embed=ERR_UNREASON) 
+                    return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
                 else:
                     receiver = await self.update_inv_new(username, +amount, item_name, conn)
                     new_after_transaction = quantity[0] - amount
@@ -1648,7 +1648,7 @@ class Economy(commands.Cog):
                     transaction_success.set_author(name=f'Transaction made by {primm.name}',
                                                    icon_url=primm.display_avatar.url)
 
-                    await interaction.response.send_message(embed=transaction_success) 
+                    await interaction.response.send_message(embed=transaction_success) # type: ignore
 
     showcase = app_commands.Group(name="showcase", description="manage your showcased items.", guild_only=True,
                                   guild_ids=APP_GUILDS_ID)
@@ -1656,7 +1656,7 @@ class Economy(commands.Cog):
     @showcase.command(name="view", description="view your item showcase.")
     @app_commands.checks.cooldown(1, 5)
     async def view_showcase(self, interaction: discord.Interaction):
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
@@ -1698,7 +1698,7 @@ class Economy(commands.Cog):
             if should_warn_user:
                 showbed.set_footer(text="You can add more items to your showcase.")
 
-            await interaction.response.send_message(embed=showbed) 
+            await interaction.response.send_message(embed=showbed) # type: ignore
 
     @showcase.command(name="add", description="add an item to your showcase.")
     @app_commands.checks.cooldown(1, 10)
@@ -1708,11 +1708,11 @@ class Economy(commands.Cog):
                             position: int,
                             item_name: Literal['Keycard', 'Trophy', 'Clan License', 'Resistor', 'Amulet',
                             'Dynamic Item', 'Hyperion', 'Crisis', 'Odd Eye']):
-        async with self.client.pool_connection.acquire() as conn:  
+        async with self.client.pool_connection.acquire() as conn:  # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) 
+                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
 
             item_name = "_".join(item_name.split(' '))
             item_qty = await self.get_one_inv_data_new(interaction.user, item_name, conn)
@@ -1727,13 +1727,13 @@ class Economy(commands.Cog):
                         embed=membed("You already have the maximum of 3 showcase slots."))
 
                 if item_qty == 0:
-                    return await interaction.response.send_message( 
+                    return await interaction.response.send_message( # type: ignore
                         embed=membed("You cannot flex on someone with something you don't even have."))
 
                 if item_name in showcase:
                     item_index = showcase.index(item_name)
                     if item_index == position-1:
-                        return await interaction.response.send_message( 
+                        return await interaction.response.send_message( # type: ignore
                             embed=membed("You already have this item in this slot."))
 
                     showcase[item_index] = "0"
@@ -1774,11 +1774,11 @@ class Economy(commands.Cog):
     async def remove_showcase_item(self, interaction: discord.Interaction,
                            item_name: Literal['Keycard', 'Trophy', 'Clan License', 'Resistor', 'Amulet',
                            'Dynamic Item', 'Hyperion', 'Crisis', 'Odd Eye']):
-        async with self.client.pool_connection.acquire() as conn:  
+        async with self.client.pool_connection.acquire() as conn:  # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered)  
+                return await interaction.response.send_message(embed=self.not_registered)  # type: ignore
 
             item_name = "_".join(item_name.split(' '))
 
@@ -1815,11 +1815,11 @@ class Economy(commands.Cog):
     @app_commands.checks.dynamic_cooldown(owners_nolimit)
     async def view_the_shop(self, interaction: discord.Interaction):
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) 
+                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
 
             additional_notes = list()
 
@@ -1884,7 +1884,7 @@ class Economy(commands.Cog):
             cost = item["cost"]
 
             if name == item_name:
-                async with self.client.pool_connection.acquire() as conn:  
+                async with self.client.pool_connection.acquire() as conn:  # type: ignore
                     conn: asqlite_Connection
                     data = await conn.execute(f"SELECT COUNT(*) FROM inventory WHERE {stored} > 0")
                     data = await data.fetchone()
@@ -1904,9 +1904,9 @@ class Economy(commands.Cog):
                 em.add_field(name="Selling price",
                              value=f"<:robux:1146394968882151434> {floor(int(cost) / 4):,}")
 
-                return await interaction.response.send_message(embed=em) 
+                return await interaction.response.send_message(embed=em) # type: ignore
 
-        await interaction.response.send_message(f"There is no item named {item_name}.") 
+        await interaction.response.send_message(f"There is no item named {item_name}.") # type: ignore
 
     profile = app_commands.Group(name='editprofile', description='custom-profile-orientated commands for use.',
                                  guild_only=True, guild_ids=APP_GUILDS_ID)
@@ -1915,43 +1915,43 @@ class Economy(commands.Cog):
     @app_commands.checks.cooldown(1, 30)
     @app_commands.describe(text="maximum of 32 characters allowed")
     async def update_bio_profile(self, interaction: discord.Interaction, text: str):
-        async with self.client.pool_connection.acquire() as conn:  
+        async with self.client.pool_connection.acquire() as conn:  # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(  
+                return await interaction.response.send_message(  # type: ignore
                     embed=self.not_registered)
 
             if len(text) > 32:
-                return await interaction.response.send_message( 
+                return await interaction.response.send_message( # type: ignore
                     embed=membed("Title cannot exceed 32 characters."))
 
             text = sub(r'[\n\t]', '', text)
-            await self.change_bank_new(interaction.user, conn, text)
+            await self.change_bank_new(interaction.user, conn, text, "title")
 
-            await interaction.response.send_message( 
+            await interaction.response.send_message( # type: ignore
                 embed=membed(f"### {interaction.user.name}'s Profile - [{text}](https://www.dis.gd/support)\n"
                              f"Your title has been changed. A preview is shown above."))
 
     @profile.command(name='bio', description='add a bio to your profile.')
     @app_commands.checks.cooldown(1, 30)
     async def update_bio_profile(self, interaction: discord.Interaction):
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) 
-            await interaction.response.send_modal(UpdateInfo()) 
+                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
+            await interaction.response.send_modal(UpdateInfo()) # type: ignore
 
     @profile.command(name='avatar', description='change your profile avatar.')
     @app_commands.describe(url='the url of the new avatar. leave blank to remove.')
     @app_commands.checks.cooldown(1, 30)
     async def update_avatar_profile(self, interaction: discord.Interaction, url: Optional[str]):
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) 
+                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
 
         if url is None:
             res = modify_profile("delete", f"{interaction.user.id} avatar_url", url)
@@ -1960,7 +1960,7 @@ class Economy(commands.Cog):
                     res = "<:warning_nr:1195732155544911882> No custom avatar was found under your account."
                 case _:
                     res = "<:overwrite:1195729262729240666> Your avatar was removed."
-            return await interaction.response.send_message(embed=membed(res)) 
+            return await interaction.response.send_message(embed=membed(res)) # type: ignore
 
         successful = discord.Embed(colour=0x2B2D31,
                                    description=f"## <:overwrite:1195729262729240666> Your custom has been added.\n"
@@ -1968,12 +1968,12 @@ class Economy(commands.Cog):
                                                f"- If you can't see it, change it!")
         successful.set_thumbnail(url=url)
         modify_profile("update", f"{interaction.user.id} avatar_url", url)
-        await interaction.response.send_message(embed=successful) 
+        await interaction.response.send_message(embed=successful) # type: ignore
 
     @update_avatar_profile.error
     async def uap_error(self, interaction: discord.Interaction, err: discord.app_commands.AppCommandError):
         modify_profile("delete", f"{interaction.user.id} avatar_url", "who cares")
-        return await interaction.response.send_message( 
+        return await interaction.response.send_message( # type: ignore
             embed=membed(
                 f"<:warning_nr:1195732155544911882> The avatar url requested for could not be added:\n"
                 f"- The URL provided was not well formed.\n"
@@ -1987,16 +1987,16 @@ class Economy(commands.Cog):
     @app_commands.checks.cooldown(1, 30)
     async def update_vis_profile(self, interaction: discord.Interaction,
                                  mode: Literal['public', 'private']):
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) 
+                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
 
         modify_profile("update", f"{interaction.user.id} vis", mode)
         cemoji = {"private": "<:privatee:1195728566919385088>",
                   "public": "<:publice:1195728479715590205>"}
         cemoji = cemoji.get(mode)
-        await interaction.response.send_message(f"{cemoji} Your profile is now {mode}.", ephemeral=True, delete_after=7.5) 
+        await interaction.response.send_message(f"{cemoji} Your profile is now {mode}.", ephemeral=True, delete_after=7.5) # type: ignore
 
     slay = app_commands.Group(name='slay', description='manage your slay.',
                               guild_only=True,
@@ -2009,8 +2009,8 @@ class Economy(commands.Cog):
                            investment="how much robux your willing to spend on this slay (no shortcuts)")
     async def hire_slv(self, interaction: discord.Interaction, user: Optional[discord.Member],
                        new_slay_name: Optional[str], gender: Literal["male", "female"], investment: int):
-        await interaction.response.defer(thinking=True) 
-        async with self.client.pool_connection.acquire() as conn: 
+        await interaction.response.defer(thinking=True) # type: ignore
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
@@ -2079,16 +2079,16 @@ class Economy(commands.Cog):
                            slay_purge='the name of your slay, if you didn\'t pick a user.')
     async def abandon_slv(self, interaction: discord.Interaction, user: Optional[discord.Member],
                           slay_purge: Optional[str]):
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
                 return await interaction.followup.send(embed=self.not_registered)
 
             if (user is None) and (slay_purge is None):
-                return await interaction.response.send_message("You did not input any slay.") 
+                return await interaction.response.send_message("You did not input any slay.") # type: ignore
             elif (slay_purge is not None) and (user is not None):
-                return await interaction.response.send_message("You cannot name your slay if the user has also " 
+                return await interaction.response.send_message("You cannot name your slay if the user has also " # type: ignore
                                                                "been inputted. Remove this argument if needed.")
             else:
                 slays = await self.get_slays(conn, interaction.user)
@@ -2098,7 +2098,7 @@ class Economy(commands.Cog):
 
                 await self.delete_slay(conn, interaction.user, slay_purge)
 
-                return await interaction.response.send_message( 
+                return await interaction.response.send_message( # type: ignore
                 embed=membed(f"Attempted to remove {slay_purge} from your owned slays.\n"
                              f" - {len(slays)}/6 total slay slots consumed."))
 
@@ -2107,7 +2107,7 @@ class Economy(commands.Cog):
     @app_commands.describe(user='the user to view the slays of')
     async def view_all_slays(self, interaction: discord.Interaction, user: Optional[discord.Member]):
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if user is None:
@@ -2123,7 +2123,7 @@ class Economy(commands.Cog):
 
             if len(slays) == 0:
                 embed.add_field(name="Nothingness.", value="This user has no slays yet.", inline=False)
-                return await interaction.response.send_message(embed=embed) 
+                return await interaction.response.send_message(embed=embed) # type: ignore
 
             for slay in slays:
                 if 66 <= slay[4] <= 100:
@@ -2136,15 +2136,15 @@ class Economy(commands.Cog):
                                                               f'\n{ARROW}{stats.get(slay[5])}')
 
             embed.set_footer(text=f"{len(slays)}/6 slay slots consumed")
-            await interaction.response.send_message(embed=embed) 
+            await interaction.response.send_message(embed=embed) # type: ignore
 
     @slay.command(name='work', description="assign your slays to do tasks for you.")
     @app_commands.describe(duration="the time spent working (e.g, 18h or 1d 3h)")
     async def make_slay_work_pay(self, interaction: discord.Interaction, duration: str):
-        await interaction.response.defer(thinking=True) 
+        await interaction.response.defer(thinking=True) # type: ignore
 
         try:
-            async with self.client.pool_connection.acquire() as conn: 
+            async with self.client.pool_connection.acquire() as conn: # type: ignore
                 conn: asqlite_Connection
 
                 if await self.can_call_out(interaction.user, conn):
@@ -2287,32 +2287,32 @@ class Economy(commands.Cog):
     async def use_item(self, interaction: discord.Interaction,
                        item: Literal['Keycard', 'Trophy', 'Clan License', 'Resistor', 'Amulet', 'Dynamic Item', 'Hyperion', 'Crisis', 'Odd Eye']):
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user,conn):
-                return await interaction.response.send_message(embed=self.not_registered) 
+                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
 
             item = item.replace(" ", "_")
             quantity = await self.get_one_inv_data_new(interaction.user, item, conn)
 
             if not quantity:
-                return await interaction.response.send_message( 
+                return await interaction.response.send_message( # type: ignore
                     embed=membed(f"You don't have this item in your inventory."))
 
             match item:
                 case 'Keycard' | 'Resistor' | 'Hyperion' | 'Crisis':
-                    return await interaction.response.send_message(  
+                    return await interaction.response.send_message(  # type: ignore
                         content="This item cannot be used. The effects are always passively active!")
                 case 'Trophy':
                     if quantity > 1:
                         content = f'\nThey have **{quantity}** of them, WHAT A BADASS'
                     else:
                         content = ''
-                    return await interaction.response.send_message( 
+                    return await interaction.response.send_message( # type: ignore
                         f"{interaction.user.name} is flexing on you all with their <:tr1:1165936712468418591> **~~PEPE~~ TROPHY**{content}")
                 case _:
-                    return await interaction.response.send_message( 
+                    return await interaction.response.send_message( # type: ignore
                         embed=membed("The functions for this item aren't available.\n"
                                      "If you wish to submit an idea for what these items do, "
                                      "comment on [this issue on our Github.](https://github.com/SGA-A/c2c/issues/12)")
@@ -2326,10 +2326,10 @@ class Economy(commands.Cog):
                       job_name: Literal['Plumber', 'Cashier', 'Fisher', 'Janitor',
                                         'Youtuber', 'Police', 'I want to resign!']):
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) 
+                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
 
             cooldown = await self.fetch_cooldown(conn, user=interaction.user, cooldown_type="job_change")
             current_job = await self.get_job_data_only(interaction.user, conn)
@@ -2348,10 +2348,10 @@ class Economy(commands.Cog):
                                                            new_cd=ncd)
 
                                 await self.change_job_new(interaction.user, conn, job_name='None')
-                                return await interaction.response.send_message( 
+                                return await interaction.response.send_message( # type: ignore
                                     embed=membed(f"Alright, I've removed you from your job.\n"
                                                  f"You cannot apply to another job for the next **48 hours**."))
-                            return await interaction.response.send_message( 
+                            return await interaction.response.send_message( # type: ignore
                                 embed=membed("You're already unemployed!?"))
 
                         ncd = datetime.datetime.now() + datetime.timedelta(days=2)
@@ -2359,10 +2359,10 @@ class Economy(commands.Cog):
                         await self.update_cooldown(conn, user=interaction.user, cooldown_type="job_change", new_cd=ncd)
 
                         await self.change_job_new(interaction.user, conn, job_name=job_name)
-                        return await interaction.response.send_message( 
+                        return await interaction.response.send_message( # type: ignore
                             embed=membed(f"Congratulations, you've been hired.\n"
-                                         f"Starting today, you are working as a {job_name.lower()}."))  
-                    return await interaction.response.send_message( 
+                                         f"Starting today, you are working as a {job_name.lower()}."))  # type: ignore
+                    return await interaction.response.send_message( # type: ignore
                         embed=membed(f"You're already a {job_name.lower()}!"))
 
                 else:
@@ -2379,7 +2379,7 @@ class Economy(commands.Cog):
                         else:
                             response = "You've done the paperwork and have now resigned from your previous job."
 
-                        await interaction.response.send_message( 
+                        await interaction.response.send_message( # type: ignore
                             embed=membed(f"{response}\n"
                                          f"Call this command again to begin your new career.")
                         )
@@ -2389,7 +2389,7 @@ class Economy(commands.Cog):
                                               description=f"You can change your job "
                                                           f"{discord.utils.format_dt(when, 'R')}.",
                                               colour=0x2B2D31)
-                        await interaction.response.send_message(embed=embed) 
+                        await interaction.response.send_message(embed=embed) # type: ignore
 
     @app_commands.command(name='profile', description='view user information and stats.')
     @app_commands.guilds(discord.Object(id=829053898333225010), discord.Object(id=780397076273954886))
@@ -2401,19 +2401,22 @@ class Economy(commands.Cog):
         user = user or interaction.user
         category = category or "Main Profile"
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
 
             if await self.can_call_out(user, conn):
-                return await interaction.response.send_message(embed=NOT_REGISTERED) 
-
-            data = await conn.execute(f"SELECT * FROM `bank` WHERE userID = ?", (user.id,))
-            data = await data.fetchone()
+                return await interaction.response.send_message(embed=NOT_REGISTERED) # type: ignore
 
             ephemerality = False
 
             if category == "Main Profile":
+
+                data = await conn.execute(
+                    f"SELECT wallet, bank, cmds_ran, showcase, title, bounty, prestige FROM `{BANK_TABLE_NAME}` WHERE userID = ?",
+                    (user.id,))
+                data = await data.fetchone()
+
                 if (get_profile_key_value(f"{user.id} vis") == "private") and (interaction.user.id != user.id):
-                    return await interaction.response.send_message(  
+                    return await interaction.response.send_message(  # type: ignore
                         embed=membed(f"# <:security:1153754206143000596> {user.name}'s profile is protected.\n"
                                      f"Only approved users can view {user.name}'s profile."))
 
@@ -2442,7 +2445,7 @@ class Economy(commands.Cog):
                     case _:
                         note = ""
 
-                showcase: str = data[16]
+                showcase: str = data[3]
                 showcase: list = showcase.split(" ")
 
                 nshowcase = []
@@ -2458,16 +2461,16 @@ class Economy(commands.Cog):
                     except IndexError:
                         continue
 
-                procfile.description = (f"### {user.name}'s Profile - [{data[17]}](https://www.dis.gd/support)\n"
+                procfile.description = (f"### {user.name}'s Profile - [{data[4]}](https://www.dis.gd/support)\n"
                                         f"{note}"
                                         f"{PRESTIGE_EMOTES.setdefault(data[-1], "")} Prestige Level **{data[-1]}**\n"
-                                        f"<:bountybag:1195653667135692800> Bounty: \U000023e3 **{data[-2]:,}**\n"
+                                        f"<:bountybag:1195653667135692800> Bounty: \U000023e3 **{data[5]:,}**\n"
                                         f"{get_profile_key_value(f"{user.id} badges") or "No badges acquired yet"}")
 
                 procfile.add_field(name='Robux',
-                                   value=f"Wallet: `\U000023e3 {format_number_short(data[1])}`\n"
-                                         f"Bank: `\U000023e3 {format_number_short(data[2])}`\n"
-                                         f"Net: `\U000023e3 {format_number_short(data[1] + data[2])}`")
+                                   value=f"Wallet: `\U000023e3 {format_number_short(int(data[0]))}`\n"
+                                         f"Bank: `\U000023e3 {format_number_short(data[1])}`\n"
+                                         f"Net: `\U000023e3 {format_number_short(data[0] + data[1])}`")
 
                 procfile.add_field(name='Items',
                                    value=f"Unique: `{unique:,}`\n"
@@ -2480,7 +2483,7 @@ class Economy(commands.Cog):
                                          f"XP: `{format_number_short(tatsu.xp)}`")
 
                 procfile.add_field(name='Commands',
-                                   value=f"Total: `{format_number_short(data[15])}`")
+                                   value=f"Total: `{format_number_short(data[2])}`")
 
                 procfile.add_field(name="Drones",
                                    value="See [#32](https://github.com/SGA-A/c2c/issues/32)")
@@ -2498,23 +2501,29 @@ class Economy(commands.Cog):
                         procfile.set_thumbnail(url=user.display_avatar.url)
                 else:
                     procfile.set_thumbnail(url=user.display_avatar.url)
-                return await interaction.response.send_message( 
+                return await interaction.response.send_message( # type: ignore
                     embed=procfile, silent=True, ephemeral=ephemerality)
             else:
-                total_slots = data[3] + data[4]
-                total_bets = data[5] + data[6]
-                total_blackjacks = data[7] + data[8]
+
+                data = await conn.execute(
+                    f"SELECT slotw, slotl, betw, betl, bjw, bjl, slotwa, slotla, betwa, betla, bjwa, bjla FROM `{BANK_TABLE_NAME}` WHERE userID = ?",
+                    (user.id,))
+                data = await data.fetchone()
+
+                total_slots = data[0] + data[1]
+                total_bets = data[2] + data[3]
+                total_blackjacks = data[4] + data[5]
 
                 try:
-                    winbe = round((data[5] / total_bets) * 100)
+                    winbe = round((data[2] / total_bets) * 100)
                 except ZeroDivisionError:
                     winbe = 0
                 try:
-                    winsl = round((data[3] / total_slots) * 100)
+                    winsl = round((data[0] / total_slots) * 100)
                 except ZeroDivisionError:
                     winsl = 0
                 try:
-                    winbl = round((data[7] / total_blackjacks) * 100)
+                    winbl = round((data[4] / total_blackjacks) * 100)
                 except ZeroDivisionError:
                     winbl = 0
 
@@ -2522,23 +2531,23 @@ class Economy(commands.Cog):
                                       colour=0x2B2D31)
                 stats.description = "**Reminder:** Games that have resulted in a tie are not tracked."
                 stats.add_field(name=f"BET ({total_bets:,})",
-                                value=f"Won: \U000023e3 {data[11]:,}\n"
-                                      f"Lost: \U000023e3 {data[12]:,}\n"
-                                      f"Net: \U000023e3 {data[11] - data[12]:,}\n"
-                                      f"Win: {winbe}% ({data[5]})")
+                                value=f"Won: \U000023e3 {data[8]:,}\n"
+                                      f"Lost: \U000023e3 {data[9]:,}\n"
+                                      f"Net: \U000023e3 {data[8] - data[9]:,}\n"
+                                      f"Win: {winbe}% ({data[2]})")
                 stats.add_field(name=f"SLOTS ({total_slots:,})",
-                                value=f"Won: \U000023e3 {data[9]:,}\n"
-                                      f"Lost: \U000023e3 {data[10]:,}\n"
-                                      f"Net: \U000023e3 {data[9] - data[10]:,}\n"
-                                      f"Win: {winsl}% ({data[3]})")
+                                value=f"Won: \U000023e3 {data[6]:,}\n"
+                                      f"Lost: \U000023e3 {data[7]:,}\n"
+                                      f"Net: \U000023e3 {data[6] - data[7]:,}\n"
+                                      f"Win: {winsl}% ({data[0]})")
                 stats.add_field(name=f"BLACKJACK ({total_blackjacks:,})",
-                                value=f"Won: \U000023e3 {data[13]:,}\n"
-                                      f"Lost: \U000023e3 {data[14]:,}\n"
-                                      f"Net: \U000023e3 {data[13] - data[14]:,}\n"
-                                      f"Win: {winbl}% ({data[7]})")
+                                value=f"Won: \U000023e3 {data[10]:,}\n"
+                                      f"Lost: \U000023e3 {data[11]:,}\n"
+                                      f"Net: \U000023e3 {data[10] - data[11]:,}\n"
+                                      f"Win: {winbl}% ({data[4]})")
                 stats.set_footer(text="The number next to the name is how many matches are recorded")
 
-                await interaction.response.send_message(embed=stats)  
+                await interaction.response.send_message(embed=stats)  # type: ignore
                 resp = await interaction.original_response()
                 try:
                     its_sum = total_bets + total_slots + total_blackjacks
@@ -2576,10 +2585,10 @@ class Economy(commands.Cog):
             else:
                 return True
 
-        async with self.client.pool_connection.acquire() as conn:  
+        async with self.client.pool_connection.acquire() as conn:  # type: ignore
             conn: asqlite_Connection
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) 
+                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
 
             real_amount = determine_exponent(robux)
             wallet_amt = await self.get_wallet_data_only(interaction.user, conn)
@@ -2592,7 +2601,7 @@ class Economy(commands.Cog):
                         real_amount = 50000000
 
             if not (is_valid(int(real_amount), wallet_amt)):
-                return await interaction.response.send_message(embed=ERR_UNREASON) 
+                return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
 
             number = randint(1, 100)
             hint = randint(1, 100)
@@ -2603,7 +2612,7 @@ class Economy(commands.Cog):
             query.set_author(name=f"{interaction.user.name}'s high-low game",
                              icon_url=interaction.user.display_avatar.url)
             query.set_footer(text="The jackpot button is if you think it is the same!")
-            await interaction.response.send_message( 
+            await interaction.response.send_message( # type: ignore
                 view=HighLow(interaction, self.client, hint_provided=hint, bet=real_amount, value=number),
                 embed=query)
 
@@ -2618,11 +2627,11 @@ class Economy(commands.Cog):
     @app_commands.describe(amount='an integer to bet upon. Supports Shortcuts (max, all, exponents).')
     async def slots(self, interaction: discord.Interaction, amount: str):
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                await interaction.response.send_message(embed=self.not_registered) 
+                await interaction.response.send_message(embed=self.not_registered) # type: ignore
 
         # --------------- Checks before betting i.e. has keycard, meets bet constraints. -------------
         data = await self.get_one_inv_data_new(interaction.user, "Keycard", conn)
@@ -2644,26 +2653,26 @@ class Economy(commands.Cog):
                 else:
                     amount = min(50_000_000, wallet_amt)
             else:
-                return await interaction.response.send_message(embed=ERR_UNREASON)  
+                return await interaction.response.send_message(embed=ERR_UNREASON)  # type: ignore
 
         # --------------- Contains checks before betting i.e. has keycard, meets bet constraints. -------------
         if data >= 1:
             if not (30000 <= amount <= 75000000):
-                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=(  
+                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=(  # type: ignore
                     f'## You did not meet the slot machine criteria.\n'
                     f'- You wanted to bet {CURRENCY}**{amount:,}**\n'
                     f' - A minimum bet of {CURRENCY}**30,000** must be made\n'
                     f' - A maximum bet of {CURRENCY}**75,000,000** can only be made.'
                 )))
             elif amount > wallet_amt:
-                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=(  
+                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=(  # type: ignore
                     f'Cannot perform this action.\n'
                     f'You only have {CURRENCY}**{wallet_amt:,}**.\n'
                     f'You\'ll need {CURRENCY}**{amount - wallet_amt:,}** more in your wallet first.'
                 )))
         else:
             if not (50000 <= amount <= 50000000):
-                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=(  
+                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=(  # type: ignore
                     f'## You did not meet the slot machine criteria.\n'
                     f'- You wanted to bet {CURRENCY}**{amount:,}**\n'
                     f' - A minimum bet of {CURRENCY}**50,000** must be made.\n'
@@ -2671,7 +2680,7 @@ class Economy(commands.Cog):
                 )))
 
             elif amount > wallet_amt:
-                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=(  
+                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=(  # type: ignore
                     f"## Cannot perform this action.\n"
                     f"You only have {CURRENCY}**{wallet_amt:,}**.\n"
                     f"You'll need {CURRENCY}**{amount - wallet_amt:,}** more in your wallet first."
@@ -2739,7 +2748,7 @@ class Economy(commands.Cog):
             embed.set_author(name=f"{interaction.user.name}'s losing slot machine",
                              icon_url=interaction.user.display_avatar.url)
 
-        await interaction.response.send_message(embed=embed) 
+        await interaction.response.send_message(embed=embed) # type: ignore
 
     @app_commands.command(name='inventory', description='view your currently owned items.')
     @app_commands.guilds(discord.Object(id=829053898333225010), discord.Object(id=780397076273954886))
@@ -2748,13 +2757,13 @@ class Economy(commands.Cog):
         member = member or interaction.user
 
         if member.bot and member.id != self.client.user.id:
-            return await interaction.response.send_message(embed=membed("Bots do not have accounts."), delete_after=5.0) 
+            return await interaction.response.send_message(embed=membed("Bots do not have accounts."), delete_after=5.0) # type: ignore
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(member, conn):
-                return await interaction.response.send_message(embed=NOT_REGISTERED) 
+                return await interaction.response.send_message(embed=NOT_REGISTERED) # type: ignore
 
             em = discord.Embed(color=0x2F3136)
             length = 3
@@ -2786,7 +2795,7 @@ class Economy(commands.Cog):
 
                 em.add_field(
                     name=f"Nothingness.", value=f"No items were found from this user.", inline=False)
-                return await interaction.response.send_message(embed=em) 
+                return await interaction.response.send_message(embed=em) # type: ignore
 
             async def get_page_part(page: int):
 
@@ -2820,11 +2829,11 @@ class Economy(commands.Cog):
         if quantity is None:
             quantity = 1
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) 
+                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
 
             wallet_amt = await self.get_wallet_data_only(interaction.user, conn)
 
@@ -2837,7 +2846,7 @@ class Economy(commands.Cog):
                     stock_item = get_stock(item_name)
 
                     if stock_item == 0:
-                        return await interaction.response.send_message( 
+                        return await interaction.response.send_message( # type: ignore
                             embed=membed(f"## Unsuccessful Transaction\n"
                                          f"- The {ie} **{item_name}** is currently out of stock.\n"
                                          f" - Until a user who owns this item chooses to "
@@ -2847,7 +2856,7 @@ class Economy(commands.Cog):
                         proper_name = " ".join(proper_name.split("_"))
                         proper_name = make_plural(proper_name, stock_item)
                         their_name = make_plural(proper_name, quantity)
-                        return await interaction.response.send_message( 
+                        return await interaction.response.send_message( # type: ignore
                             embed=membed(f"## Unsuccessful Transaction\n"
                                          f"There are only **{stock_item}** {ie} **{proper_name.title()}** available.\n"
                                          f"{ARROW}Meaning you cannot possibly buy **{quantity}** {their_name.title()}."))
@@ -2857,7 +2866,7 @@ class Economy(commands.Cog):
                     if wallet_amt < int(total_cost):
                         proper_name = " ".join(proper_name.split("_"))
                         proper_name = make_plural(proper_name, quantity)
-                        return await interaction.response.send_message( 
+                        return await interaction.response.send_message( # type: ignore
                             embed=membed(f"## Unsuccessful Transaction\n"
                                          f"You'll need {CURRENCY}**{total_cost - wallet_amt:,}** more to "
                                          f"purchase {quantity} {ie} **{proper_name.title()}**."))
@@ -2868,7 +2877,7 @@ class Economy(commands.Cog):
 
                     match quantity:
                         case 1:
-                            return await interaction.response.send_message( 
+                            return await interaction.response.send_message( # type: ignore
                                 embed=membed(f"## Success\n"
                                              f"- Purchased **1** {ie} **{item_name}** by paying "
                                              f"{CURRENCY}**{total_cost:,}**.\n"
@@ -2876,7 +2885,7 @@ class Economy(commands.Cog):
                         case _:
                             their_name = ' '.join(proper_name.split("_"))
                             their_name = make_plural(their_name, quantity)
-                            await interaction.response.send_message( 
+                            await interaction.response.send_message( # type: ignore
                                 embed=membed(f"## Success\n"
                                              f"- Purchased **{quantity}** {ie} **{their_name.title()}** by"
                                              f" paying {CURRENCY}**{total_cost:,}**.\n"
@@ -2894,11 +2903,11 @@ class Economy(commands.Cog):
             sell_quantity = 1
 
         name = item_name.replace(" ", "_")
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) 
+                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
 
             for item in SHOP_ITEMS:
                 if name == item["name"]:
@@ -2907,12 +2916,12 @@ class Economy(commands.Cog):
                     quantity = await self.update_inv_new(interaction.user, 0, item["name"], conn)
 
                     if quantity[0] < 1:
-                        return await interaction.response.send_message( 
+                        return await interaction.response.send_message( # type: ignore
                             embed=membed(f"You don't have a {ie} **{item_name}** in your inventory."))
 
                     new_quantity = quantity[0] - sell_quantity
                     if new_quantity < 0:
-                        return await interaction.response.send_message( 
+                        return await interaction.response.send_message( # type: ignore
                             f"You are requesting to sell more than what you currently own. Not possible.")
 
                     await self.change_inv_new(interaction.user, new_quantity, item["name"], conn)
@@ -2923,14 +2932,14 @@ class Economy(commands.Cog):
                         case 1:
                             proper_name = item.setdefault('qn', None) or name
                             proper_name = ' '.join(proper_name.split('_'))
-                            return await interaction.response.send_message( 
+                            return await interaction.response.send_message( # type: ignore
                                 embed=membed(f"You just sold 1 {ie} **{proper_name.title()}** and got "
                                              f"<:robux:1146394968882151434> **{cost:,}** in return."))
                         case _:
                             proper_name = item.setdefault('qn', None) or name
                             proper_name = ' '.join(proper_name.split('_'))
                             proper_name = make_plural(proper_name, sell_quantity)
-                            return await interaction.response.send_message( 
+                            return await interaction.response.send_message( # type: ignore
                                 embed=membed(f"You just sold {sell_quantity} {ie} **{proper_name.title()}** and got "
                                              f"<:robux:1146394968882151434> **{cost:,}** in return."))
 
@@ -2938,7 +2947,7 @@ class Economy(commands.Cog):
     @app_commands.guilds(discord.Object(id=829053898333225010), discord.Object(id=780397076273954886))
     async def work(self, interaction: discord.Interaction):
 
-        await interaction.response.defer(thinking=True, ephemeral=True) 
+        await interaction.response.defer(thinking=True, ephemeral=True) # type: ignore
 
         words = {
             "Plumber": [("TOILET", "SINK", "SEWAGE", "SANITATION", "DRAINAGE", "PIPES"), 400000000],
@@ -2954,7 +2963,7 @@ class Economy(commands.Cog):
                        "INTERROGATION"), 1200000000]
         }
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
@@ -3009,11 +3018,11 @@ class Economy(commands.Cog):
     async def find_balance(self, interaction: discord.Interaction, user: Optional[discord.Member]):
         """Returns a user's balance."""
 
-        await interaction.response.defer(thinking=True) 
+        await interaction.response.defer(thinking=True) # type: ignore
 
         user = user or interaction.user
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(user, conn) and (user.id != interaction.user.id):
@@ -3081,16 +3090,16 @@ class Economy(commands.Cog):
         member = member or interaction.user
         if interaction.user.id not in {992152414566232139, 546086191414509599}:
             if (member is not None) and (member != interaction.user):
-                return await interaction.response.send_message(embed=ERR_UNREASON) 
+                return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
         else:
             if member.bot:
-                return await interaction.response.send_message(embed=ERR_UNREASON) 
+                return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(member, conn):
-                await interaction.response.send_message( 
+                await interaction.response.send_message( # type: ignore
                     embed=membed(f"Could not find {member.name} in the database."))
             else:
 
@@ -3103,7 +3112,7 @@ class Economy(commands.Cog):
                                                       "cannot recover this data again.",
                                           colour=0x2B2D31)
 
-                    await interaction.response.send_message(embed=embed, view=view)  
+                    await interaction.response.send_message(embed=embed, view=view)  # type: ignore
                     view.msg = await interaction.original_response()
                     return
 
@@ -3119,7 +3128,7 @@ class Economy(commands.Cog):
                                         colour=discord.Colour.brand_green())
                 success.set_footer(text="Some requirements were bypassed.", icon_url=self.client.user.avatar.url)
 
-                await interaction.response.send_message(embed=success) 
+                await interaction.response.send_message(embed=success) # type: ignore
 
     @app_commands.command(name="withdraw", description="withdraw robux from your account.")
     @app_commands.guilds(discord.Object(id=829053898333225010), discord.Object(id=780397076273954886))
@@ -3130,10 +3139,10 @@ class Economy(commands.Cog):
         user = interaction.user
         actual_amount = determine_exponent(robux)
 
-        async with (self.client.pool_connection.acquire() as conn): 
+        async with (self.client.pool_connection.acquire() as conn): # type: ignore
             conn: asqlite_Connection
             if await self.can_call_out(interaction.user, conn):
-                await interaction.response.send_message(embed=self.not_registered) 
+                await interaction.response.send_message(embed=self.not_registered) # type: ignore
             users = await self.get_bank_data_new(user, conn)
 
             bank_amt = users[2]
@@ -3149,8 +3158,8 @@ class Economy(commands.Cog):
                     embed.add_field(name=f"Current Wallet Balance", value=f"\U000023e3 {wallet_new[0]:,}")
                     embed.add_field(name=f"Current Bank Balance", value=f"\U000023e3 {bank_new[0]:,}")
 
-                    return await interaction.response.send_message(embed=embed) 
-                return await interaction.response.send_message(embed=ERR_UNREASON) 
+                    return await interaction.response.send_message(embed=embed) # type: ignore
+                return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
 
             amount_conv = abs(int(actual_amount))
             if amount_conv < 5000:
@@ -3158,14 +3167,14 @@ class Economy(commands.Cog):
                                       description=f"- For performance reasons, a minimum of "
                                                   f"\U000023e3 **5,000** must be withdrawn.\n"
                                                   f" - You wanted to withdraw \U000023e3 **{amount_conv:,}**.\n")
-                return await interaction.response.send_message(embed=embed) 
+                return await interaction.response.send_message(embed=embed) # type: ignore
 
             elif amount_conv > bank_amt:
                 embed = discord.Embed(colour=0x2F3136,
                                       description=f"- You do not have that much money in your bank.\n"
                                                   f" - You wanted to withdraw \U000023e3 **{amount_conv:,}**.\n"
                                                   f" - Currently, you only have \U000023e3 **{bank_amt:,}**.")
-                return await interaction.response.send_message(embed=embed) 
+                return await interaction.response.send_message(embed=embed) # type: ignore
 
             else:
                 wallet_new = await self.update_bank_new(user, conn, +amount_conv)
@@ -3176,7 +3185,7 @@ class Economy(commands.Cog):
                 embed.add_field(name=f"Current Wallet Balance", value=f"\U000023e3 {wallet_new[0]:,}")
                 embed.add_field(name=f"Current Bank Balance", value=f"\U000023e3 {bank_new[0]:,}")
 
-                return await interaction.response.send_message(embed=embed) 
+                return await interaction.response.send_message(embed=embed) # type: ignore
 
     @app_commands.command(name='deposit', description="deposit robux to your bank account.")
     @app_commands.guilds(discord.Object(id=829053898333225010), discord.Object(id=780397076273954886))
@@ -3186,11 +3195,11 @@ class Economy(commands.Cog):
         user = interaction.user
         actual_amount = determine_exponent(robux)
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) 
+                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
             users = await self.get_bank_data_new(user, conn)
             wallet_amt = users[1]
             if isinstance(actual_amount, str):
@@ -3203,8 +3212,8 @@ class Economy(commands.Cog):
                     embed.add_field(name="Current Wallet Balance", value=f"\U000023e3 {wallet_new[0]:,}")
                     embed.add_field(name="Current Bank Balance", value=f"\U000023e3 {bank_new[0]:,}")
 
-                    return await interaction.response.send_message(embed=embed) 
-                return await interaction.response.send_message(embed=ERR_UNREASON) 
+                    return await interaction.response.send_message(embed=embed) # type: ignore
+                return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
 
             amount_conv = abs(int(actual_amount))
             if amount_conv < 5000:
@@ -3212,14 +3221,14 @@ class Economy(commands.Cog):
                                       description=f"- For performance reasons, a minimum of "
                                                   f"\U000023e3 **5,000** must be deposited.\n"
                                                   f" - You wanted to deposit \U000023e3 **{amount_conv:,}**.\n")
-                return await interaction.response.send_message(embed=embed) 
+                return await interaction.response.send_message(embed=embed) # type: ignore
 
             elif amount_conv > wallet_amt:
                 embed = discord.Embed(colour=0x2F3136,
                                       description=f"- You do not have that much money in your wallet.\n"
                                                   f" - You wanted to deposit \U000023e3 **{amount_conv:,}**.\n"
                                                   f" - Currently, you only have \U000023e3 **{wallet_amt:,}**.")
-                return await interaction.response.send_message(embed=embed) 
+                return await interaction.response.send_message(embed=embed) # type: ignore
             else:
                 wallet_new = await self.update_bank_new(user, conn, -amount_conv)
                 bank_new = await self.update_bank_new(user, conn, +amount_conv, "bank")  # \U000023e3
@@ -3229,14 +3238,14 @@ class Economy(commands.Cog):
                 embed.add_field(name="Current Wallet Balance", value=f"\U000023e3 {wallet_new[0]:,}")
                 embed.add_field(name="Current Bank Balance", value=f"\U000023e3 {bank_new[0]:,}")
 
-                return await interaction.response.send_message(embed=embed) 
+                return await interaction.response.send_message(embed=embed) # type: ignore
 
     @app_commands.command(name='leaderboard', description='rank users based on various stats.')
     @app_commands.guilds(discord.Object(id=829053898333225010), discord.Object(id=780397076273954886))
     @app_commands.checks.dynamic_cooldown(owners_nolimit)
     async def get_leaderboard(self, interaction: discord.Interaction):
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection = conn
 
             data = await conn.execute(
@@ -3271,7 +3280,7 @@ class Economy(commands.Cog):
                 icon_url=self.client.user.avatar.url)
 
         lb_view = Leaderboard(self.client)
-        await interaction.response.send_message(embed=lb, view=lb_view) 
+        await interaction.response.send_message(embed=lb, view=lb_view) # type: ignore
         lb_view.message = await interaction.original_response()
 
     @commands.guild_only()
@@ -3320,22 +3329,22 @@ class Economy(commands.Cog):
         primary_id = str(interaction.user.id)
         other_id = str(other.id)
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if other_id == primary_id:
                 embed = membed('You cannot rob yourself, everyone knows that.')
-                return await interaction.response.send_message(embed=embed) 
+                return await interaction.response.send_message(embed=embed) # type: ignore
             elif other.bot:
                 embed = membed('You are not allowed to steal from bots, back off my kind')
-                return await interaction.response.send_message(embed=embed) 
+                return await interaction.response.send_message(embed=embed) # type: ignore
             elif other_id == "992152414566232139":
                 embed = membed('You are not allowed to rob the developer of this bot.')
-                return await interaction.response.send_message(embed=embed) 
+                return await interaction.response.send_message(embed=embed) # type: ignore
             elif not (await self.can_call_out_either(interaction.user, other, conn)):
                 embed = membed(f'- Either you or {other.name} does not have an account.\n'
                                f' - </balance:1179817617435926686> to register.')
-                return await interaction.response.send_message(embed=embed) 
+                return await interaction.response.send_message(embed=embed) # type: ignore
             else:
                 prim_bal = await self.get_bank_data_new(interaction.user, conn)
                 host_bal = await self.get_bank_data_new(other, conn)
@@ -3352,7 +3361,7 @@ class Economy(commands.Cog):
                     await self.update_bank_new(other, conn, +fine)
                     conte = (f'- You were caught stealing now you paid {other.name} \U000023e3 **{fine:,}**.\n'
                              f'- **{prcf}**% of your money was handed over to the victim.')
-                    return await interaction.response.send_message(embed=membed(conte)) 
+                    return await interaction.response.send_message(embed=membed(conte)) # type: ignore
                 else:
                     steal_amount = randint(1, host_bal[1])
                     await self.update_bank_new(interaction.user, conn, +steal_amount)
@@ -3360,7 +3369,7 @@ class Economy(commands.Cog):
 
                     prcf = round((steal_amount / host_bal[1]) * 100, ndigits=1)
 
-                    return await interaction.response.send_message( 
+                    return await interaction.response.send_message( # type: ignore
                         embed=membed(f"- You managed to steal \U000023e3 **{steal_amount:,}** from {other.name}.\n"
                                      f"- You took a dandy **{prcf}**% of {other.name}'s `wallet` balance."),
                         delete_after=10.0)
@@ -3368,9 +3377,9 @@ class Economy(commands.Cog):
     @rob.command(name='casino', description='rob a casino vault.')
     async def rob_the_casino(self, interaction: discord.Interaction):
 
-        await interaction.response.defer() 
+        await interaction.response.defer() # type: ignore
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
 
             if await self.can_call_out(interaction.user, conn):
@@ -3486,33 +3495,33 @@ class Economy(commands.Cog):
     async def coinflip(self, interaction: discord.Interaction, bet_on: str, amount: int):
         user = interaction.user
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
 
             amount = determine_exponent(str(amount))
 
             bet_on = "heads" if "h" in bet_on.lower() else "tails"
             if not 5000 <= amount <= 100_000_000:
-                return await interaction.response.send_message(  
+                return await interaction.response.send_message(  # type: ignore
                     embed=membed(f"*As per-policy*, the minimum bet is {CURRENCY}**5,000**, the maximum is "
                                  f"{CURRENCY}**200,000,000**."))
 
             conn: asqlite_Connection
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) 
+                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
             wallet_amt = await self.get_wallet_data_only(user, conn)
             if wallet_amt < amount:
-                return await interaction.response.send_message(embed=ERR_UNREASON) 
+                return await interaction.response.send_message(embed=ERR_UNREASON) # type: ignore
 
             coin = ["heads", "tails"]
             result = choice(coin)
 
             if result != bet_on:
                 await self.update_bank_new(user, conn, -amount)
-                return await interaction.response.send_message( 
+                return await interaction.response.send_message( # type: ignore
                     embed=membed(f"You got {result}, meaning you lost \U000023e3 **{amount:,}**."))
 
             await self.update_bank_new(user, conn, +amount)
-            return await interaction.response.send_message(embed=membed(f"You got {result}, meaning you won \U000023e3 " 
+            return await interaction.response.send_message(embed=membed(f"You got {result}, meaning you won \U000023e3 " # type: ignore
                                                                         f"**{amount:,}**."))
 
     @app_commands.command(name="blackjack",
@@ -3524,8 +3533,8 @@ class Economy(commands.Cog):
     async def play_blackjack(self, interaction: discord.Interaction, bet_amount: str):
 
         # ------ Check the user is registered or already has an ongoing game ---------
-        if len(self.client.games) >= 2: 
-            return await interaction.response.send_message( 
+        if len(self.client.games) >= 2: # type: ignore
+            return await interaction.response.send_message( # type: ignore
                 embed=membed(
                     "- The maximum consecutive blackjack games being held has been reached.\n"
                     "- To prevent server overload, you cannot start a game until the current games "
@@ -3534,14 +3543,14 @@ class Economy(commands.Cog):
                 )
             )
 
-        if self.client.games.setdefault(interaction.user.id, None) is not None: 
-            return await interaction.response.send_message( 
+        if self.client.games.setdefault(interaction.user.id, None) is not None: # type: ignore
+            return await interaction.response.send_message( # type: ignore
                 "You already have an ongoing game taking place.")
 
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             conn: asqlite_Connection
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) 
+                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
 
         # ----------------- Game setup ---------------------------------
 
@@ -3570,38 +3579,38 @@ class Economy(commands.Cog):
                 else:
                     namount = min(50_000_000, wallet_amt)
             else:
-                return await interaction.response.send_message(embed=ERR_UNREASON)  
+                return await interaction.response.send_message(embed=ERR_UNREASON)  # type: ignore
 
         # -------------------- Check to see if user has sufficient balance --------------------------
 
         if has_keycard:
             if not (500_000 <= namount <= 100_000_000):
-                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=( 
+                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=( # type: ignore
                     f'## You did not meet the blackjack criteria.\n'
                     f'- You wanted to bet {CURRENCY}**{namount:,}**\n'
                     f' - A minimum bet of {CURRENCY}**500,000** must be made\n'
                     f' - A maximum bet of {CURRENCY}**100,000,000** can only be made.'
-                )))  
+                )))  # type: ignore
             elif namount > wallet_amt:
-                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=( 
+                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=( # type: ignore
                     f'Cannot perform this action.\n'
                     f'You only have {CURRENCY}**{wallet_amt:,}**.\n'
                     f'You\'ll need {CURRENCY}**{namount - wallet_amt:,}** more in your wallet first.'
-                )))  
+                )))  # type: ignore
         else:
             if not (1000000 <= namount <= 50_000_000):
-                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=( 
+                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=( # type: ignore
                     f'## You did not meet the blackjack criteria.\n'
                     f'- You wanted to bet {CURRENCY}**{namount:,}**\n'
                     f' - A minimum bet of {CURRENCY}**1,000,000** must be made.\n'
                     f' - A maximum bet of {CURRENCY}**50,000,000** can only be made.'
-                )))  
+                )))  # type: ignore
             elif namount > wallet_amt:
-                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=( 
+                return await interaction.response.send_message(embed=discord.Embed(colour=0x2F3136, description=( # type: ignore
                     f"## Cannot perform this action.\n"
                     f"You only have {CURRENCY}**{wallet_amt:,}**.\n"
                     f"You'll need {CURRENCY}**{namount - wallet_amt:,}** more in your wallet first."
-                )))  
+                )))  # type: ignore
 
         # ------------ In the case where the user already won --------------
         if self.calculate_hand(player_hand) == 21:
@@ -3632,7 +3641,7 @@ class Economy(commands.Cog):
             embed.add_field(name=f"{interaction.guild.me.name} (Dealer)",
                             value=f"**Cards** - {' '.join(d_fver_d)}\n"
                                   f"**Total** - {sum(dealer_hand)}")
-            return await interaction.response.send_message(embed=embed) 
+            return await interaction.response.send_message(embed=embed) # type: ignore
 
         shallow_pv = []
         shallow_dv = []
@@ -3645,7 +3654,7 @@ class Economy(commands.Cog):
             remade = display_user_friendly_card_format(number)
             shallow_dv.append(remade)
 
-        self.client.games[interaction.user.id] = (deck, player_hand, dealer_hand, shallow_dv, shallow_pv, namount) 
+        self.client.games[interaction.user.id] = (deck, player_hand, dealer_hand, shallow_dv, shallow_pv, namount) # type: ignore
 
 
         start = discord.Embed(colour=0x2B2D31,
@@ -3661,7 +3670,7 @@ class Economy(commands.Cog):
         start.set_author(icon_url=interaction.user.display_avatar.url, name=f"{interaction.user.name}'s blackjack game")
         start.set_footer(text="K, Q, J = 10  |  A = 1 or 11")
         my_view = BlackjackUi(interaction, self.client)
-        await interaction.response.send_message( 
+        await interaction.response.send_message( # type: ignore
             content="What do you want to do?\nPress **Hit** to to request an additional card, **Stand** to finalize "
                     "your deck or **Forfeit** to end your hand prematurely, sacrificing half of your original bet.",
             embed=start, view=my_view)
@@ -3679,9 +3688,9 @@ class Economy(commands.Cog):
         """Bet your robux on a gamble to win or lose robux."""
 
         # --------------- Contains checks before betting i.e. has keycard, meets bet constraints. -------------
-        async with self.client.pool_connection.acquire() as conn: 
+        async with self.client.pool_connection.acquire() as conn: # type: ignore
             if await self.can_call_out(interaction.user, conn):
-                return await interaction.response.send_message(embed=self.not_registered) 
+                return await interaction.response.send_message(embed=self.not_registered) # type: ignore
             conn: asqlite_Connection
 
             data = await conn.execute(f"SELECT pmulti, wallet, betw, betl FROM `{BANK_TABLE_NAME}` WHERE userID = ?",
@@ -3701,7 +3710,7 @@ class Economy(commands.Cog):
                     else:
                         amount = min(50_000_000, wallet_amt)
                 else:
-                    return await interaction.response.send_message(embed=ERR_UNREASON)  
+                    return await interaction.response.send_message(embed=ERR_UNREASON)  # type: ignore
 
             if has_keycard:
                 if (amount > 100000000) or (amount < 100000):
@@ -3711,13 +3720,13 @@ class Economy(commands.Cog):
                                                                      f'be made\n'
                                                                      f' - A maximum bet of {CURRENCY}**100,000,000** '
                                                                      f'can only be made.')
-                    return await interaction.response.send_message(embed=err) 
+                    return await interaction.response.send_message(embed=err) # type: ignore
                 elif amount > wallet_amt:
                     err = discord.Embed(colour=0x2F3136, description=f'Cannot perform this action, '
                                                                      f'you only have {CURRENCY}**{wallet_amt:,}**.\n'
                                                                      f'You\'ll need {CURRENCY}**{amount - wallet_amt:,}**'
                                                                      f' more in your wallet first.')
-                    return await interaction.response.send_message(embed=err) 
+                    return await interaction.response.send_message(embed=err) # type: ignore
             else:
                 if (amount > 50000000) or (amount < 500000):
                     err = discord.Embed(colour=0x2F3136, description=f'## You did not meet the bet criteria:\n'
@@ -3729,13 +3738,13 @@ class Economy(commands.Cog):
                                                                      f'can only be made (this can increase when you '
                                                                      f'acquire a <:lanyard:1165935243140796487> '
                                                                      f'Keycard).')
-                    return await interaction.response.send_message(embed=err) 
+                    return await interaction.response.send_message(embed=err) # type: ignore
                 elif amount > wallet_amt:
                     err = discord.Embed(colour=0x2F3136, description=f'Cannot perform this action, '
                                                                      f'you only have {CURRENCY}**{wallet_amt:,}**.\n'
                                                                      f'You\'ll need {CURRENCY}**{amount - wallet_amt:,}**'
                                                                      f' more in your wallet first.')
-                    return await interaction.response.send_message(embed=err) 
+                    return await interaction.response.send_message(embed=err) # type: ignore
 
             # --------------------------------------------------------
             smulti = SERVER_MULTIPLIERS.setdefault(interaction.guild.id, 0) + pmulti
@@ -3791,7 +3800,7 @@ class Economy(commands.Cog):
 
             embed.add_field(name=interaction.user.name, value=f"Rolled `{your_choice[0]}` {''.join(badges)}")
             embed.add_field(name=self.client.user.name, value=f"Rolled `{bot_choice[0]}`")
-            await interaction.response.send_message(embed=embed)  
+            await interaction.response.send_message(embed=embed)  # type: ignore
 
             await self.raise_pmulti_warning(interaction, pmulti)
 


### PR DESCRIPTION
This PR adds the ability for users to modify the title displayed on their profile directly on Discord.
It does not require you to login anymore via the Tatsu dashboard.
In fact, it's integration is planned for a end of life some time this year, as we will revoke its API key and the uses.

Summary:
- Adds a subcommand
- Created a new field in the database that takes the user's title, defaults to 'No title'
- Some other random changes
