### PR TITLE
Organize imports + Hybrid

### DIFF
--- a/cogs/ctx-events.py
+++ b/cogs/ctx-events.py
@@ -53,7 +53,7 @@ class ContextCommandHandler(commands.Cog):
                     description=f"## Missing Permissions\n"
                                 f"You're missing some permissions required to use this command.",
                     colour=0x2F3136)
-                errorc.add_field(name='Required permissions', 
+                errorc.add_field(name='Required permissions',
                                  value=', '.join(err.missing_permissions), inline=False)
                 await ctx.reply(embed=errorc, mention_author=False)
 
@@ -62,19 +62,11 @@ class ContextCommandHandler(commands.Cog):
                 exception = Embed(description=f'## You need a required role', colour=0x2F3136)
                 exception.add_field(name='Required Role', value=f"<@&{err.missing_role}>", inline=False)
                 await ctx.reply(embed=exception, mention_author=False)
-
-            elif isinstance(err, errors.NoPrivateMessage):
-                embed = membed(
-                    f"## Do not send private messages.\n"
-                    f"Use my commands in a server, for example in {ctx.author.mutual_guilds[0].name}.")
-                msg = await ctx.send(embed=embed)
-                await msg.delete(delay=15.0)
-                return
             else:
-                
+
                 await ctx.reply(
                     embed=membed(f"## Checks Failed\n"
-                                 f"You have not met a prerequisite before executing this command."), 
+                                 f"You have not met a prerequisite before executing this command."),
                     mention_author=False)
 
         elif isinstance(err, errors.CommandOnCooldown):

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -2,8 +2,6 @@ from other.utilities import *
 from asyncio import sleep, TimeoutError as asyncTE
 from string import ascii_letters, digits
 from shelve import open as open_shelve
-import datetime
-import discord
 from re import sub, search
 from other.pagination import Pagination
 from ImageCharts import ImageCharts
@@ -12,9 +10,12 @@ from math import floor, ceil
 from random import randint, choices, choice, sample, shuffle
 from pluralizer import Pluralizer
 from discord import app_commands, SelectOption
-import json
 from asqlite import Connection as asqlite_Connection
 from typing import Optional, Literal, Any, Union, List
+
+import discord
+import datetime
+import json
 
 
 def membed(custom_description: str) -> discord.Embed:

--- a/cogs/miscellaneous.py
+++ b/cogs/miscellaneous.py
@@ -1,10 +1,8 @@
 from time import perf_counter
 from PyDictionary import PyDictionary
-import discord
 from xml.etree.ElementTree import fromstring
 from other.pagination import Pagination
 from io import BytesIO
-import datetime
 from random import choice
 from github import Github
 from re import compile as compile_it
@@ -15,6 +13,9 @@ from discord.ext import commands
 from other.spshit import get_song_attributes
 from discord import app_commands, Interaction, Object
 from unicodedata import name
+
+import discord
+import datetime
 
 ARROW = "<:arrowe:1180428600625877054>"
 found_spotify = False
@@ -251,7 +252,7 @@ class Miscellaneous(commands.Cog):
     @app_commands.guilds(Object(id=829053898333225010), Object(id=780397076273954886))
     async def extract_source(self, interaction: discord.Interaction, message: discord.Message):
 
-        await interaction.response.send_message("Looking into it..")
+        await interaction.response.send_message("Looking into it..")  
         msg = await interaction.original_response()
         images = set()
         counter = 0
@@ -820,6 +821,7 @@ class Miscellaneous(commands.Cog):
 
     @app_commands.command(name='char', description="retrieve sfw or nsfw anime images.")
     @app_commands.guilds(Object(id=829053898333225010), Object(id=780397076273954886))
+    @app_commands.checks.cooldown(1, 4)
     @app_commands.describe(filter_by='what type of image to retrieve')
     async def get_via_nekos(self, interaction: discord.Interaction,
                             filter_by: Optional[

--- a/cogs/slash-events.py
+++ b/cogs/slash-events.py
@@ -22,8 +22,8 @@ class SlashExceptionHandler(commands.Cog):
     async def get_app_command_error(self, interaction: Interaction,
                                     error: AppCommandError):
 
-        if not interaction.response.is_done():  # type: ignore
-            await interaction.response.defer(thinking=True)  # type: ignore
+        if not interaction.response.is_done():  
+            await interaction.response.defer(thinking=True)  
 
         if isinstance(error, CheckFailure):
             exception = Embed(title='Exception', colour=0x2B2D31)

--- a/cogs/slash-events.py
+++ b/cogs/slash-events.py
@@ -1,11 +1,12 @@
-import datetime
 from discord.utils import format_dt
 from random import choice
 from traceback import print_exception
-from discord import Embed, Interaction, Colour
+from discord import Embed, Interaction
 from discord.ext import commands
 from discord.app_commands import AppCommandError, CheckFailure, MissingRole, MissingPermissions
 from discord.app_commands import CommandOnCooldown, CommandNotFound, CommandAlreadyRegistered, CommandInvokeError
+
+import datetime
 
 
 class SlashExceptionHandler(commands.Cog):
@@ -21,11 +22,11 @@ class SlashExceptionHandler(commands.Cog):
     async def get_app_command_error(self, interaction: Interaction,
                                     error: AppCommandError):
 
-        if not interaction.response.is_done():  
-            await interaction.response.defer(thinking=True)  
+        if not interaction.response.is_done():  # type: ignore
+            await interaction.response.defer(thinking=True)  # type: ignore
 
         if isinstance(error, CheckFailure):
-            exception = Embed(title='Exception', colour=Colour.dark_embed())
+            exception = Embed(title='Exception', colour=0x2B2D31)
             exception.set_thumbnail(url="https://i.imgur.com/zGtq4Dp.png")
             if isinstance(error, MissingRole):  # when a user has a missing role
 
@@ -42,7 +43,7 @@ class SlashExceptionHandler(commands.Cog):
 
             elif isinstance(error, CommandOnCooldown):  # when the command a user executes is on cooldown
                 exception.title = choice([
-                    "Too spicy, take a breather..", "Take a chill pill", "Woah now, slow it down", 
+                    "Too spicy, take a breather..", "Take a chill pill", "Woah now, slow it down",
                     "Let's slow it down here", "Slow it down bud", "Spam isn't cool fam", "Hold your horses..."])
                 exception.set_thumbnail(url=None)
                 exception.colour = 0x2B2D31
@@ -57,17 +58,16 @@ class SlashExceptionHandler(commands.Cog):
             content = Embed(
                 description=f"The commmand with name {error.name} was not found.\n"
                             f"It may have been recently removed or replaced with an alternative.",
-                colour=Colour.dark_embed())
+                colour=0x2B2D31)
             content.set_thumbnail(url="https://i.imgur.com/zGtq4Dp.png")
 
             return await interaction.followup.send(content)
 
         if isinstance(error, CommandAlreadyRegistered):
-
             content = Embed(
                 description=f"{interaction.user.name}, this command is registered already?\n"
                             f"This is an issue with the bot, usually resolving itself within a few minutes.",
-                colour=Colour.dark_embed())
+                colour=0x2B2D31)
             content.set_thumbnail(url="https://i.imgur.com/zGtq4Dp.png")
             return await interaction.followup.send(content)
 
@@ -80,7 +80,7 @@ class SlashExceptionHandler(commands.Cog):
                                         f"50% chance its a issue on your end, 50% chance on our end.\n"
                                         f"**The bot developers were notified.** "
                                         f"[See their progress.](https://github.com/SGA-A/c2c/issues)",
-                            colour=Colour.dark_embed()).set_thumbnail(url="https://i.imgur.com/zGtq4Dp.png"))
+                            colour=0x2B2D31).set_thumbnail(url="https://i.imgur.com/zGtq4Dp.png"))
 
         else:
             print_exception(type(error), error, error.__traceback__)

--- a/main.py
+++ b/main.py
@@ -142,12 +142,12 @@ class MyCommandTree(app_commands.CommandTree):
                 options: List[Union[app_commands.AppCommand, app_commands.AppCommandGroup, app_commands.Argument]]):
             for option in options:
                 if isinstance(option, app_commands.AppCommandGroup):
-                    ret[option.qualified_name] = option  # type: ignore
-                    unpack_options(option.options)  # type: ignore
+                    ret[option.qualified_name] = option  
+                    unpack_options(option.options)  
 
         for command in commandsr:
             ret[command.name] = command
-            unpack_options(command.options)  # type: ignore
+            unpack_options(command.options)  
 
         return ret
 
@@ -318,7 +318,7 @@ class SelectMenu(ui.Select):
                     cmd_formatter.add(f"\U0000279c [`>{cmd}`](https://youtu.be/dQw4w9WgXcQ) - {cmd_details[1]}")
                     continue
 
-                command_manage = client.tree.get_app_command(cmd, guild=Object(id=interaction.guild.id))  # type: ignore
+                command_manage = client.tree.get_app_command(cmd, guild=Object(id=interaction.guild.id))  
                 cmd_formatter.add(f"\U0000279c **{command_manage.mention}** - {cmd_details[1]}")
 
             embed.add_field(name='About: Owner',
@@ -335,13 +335,13 @@ class SelectMenu(ui.Select):
 
             embed.description = "\n".join(cmd_formatter)
 
-            await interaction.response.edit_message(embed=embed, view=self.view)  # type: ignore
+            await interaction.response.edit_message(embed=embed, view=self.view)  
 
         elif their_choice == 'Moderation':
 
             the_dict = {}
-            new_dict = return_txt_cmds_first(the_dict, their_choice)  # type: ignore
-            all_cmdss: dict = return_interaction_cmds_last(new_dict, their_choice)  # type: ignore
+            new_dict = return_txt_cmds_first(the_dict, their_choice)  
+            all_cmdss: dict = return_interaction_cmds_last(new_dict, their_choice)  
 
             embed = Embed(title='Help: Moderation', colour=Colour.from_rgb(247, 14, 115))
             embed.set_thumbnail(url='https://emoji.discadia.com/emojis/74e65408-2adb-46dc-86a7-363f3096b6b2.PNG')
@@ -361,7 +361,7 @@ class SelectMenu(ui.Select):
                                   f'- Status: **READY**')
             embed.description = "\n".join(cmd_formatter)
 
-            await interaction.response.edit_message(embed=embed, view=self.view)  # type: ignore
+            await interaction.response.edit_message(embed=embed, view=self.view)  
 
         elif their_choice == 'Utility':
 
@@ -377,7 +377,7 @@ class SelectMenu(ui.Select):
                 if cmd_details[-1] == 'txt':
                     cmd_formatter.add(f"\U0000279c [`>{cmd}`](https://youtu.be/dQw4w9WgXcQ) - {cmd_details[1]}")
                     continue
-                command_manage = client.tree.get_app_command(cmd, guild=Object(id=interaction.guild.id))  # type: ignore
+                command_manage = client.tree.get_app_command(cmd, guild=Object(id=interaction.guild.id))  
                 cmd_formatter.add(f"\U0000279c **{command_manage.mention}** - {cmd_details[1]}")
 
             embed.add_field(name='About: Utility',
@@ -391,7 +391,7 @@ class SelectMenu(ui.Select):
                                   f'- Status: **READY**')
             embed.description = "\n".join(cmd_formatter)
 
-            await interaction.response.edit_message(embed=embed, view=self.view)  # type: ignore
+            await interaction.response.edit_message(embed=embed, view=self.view)  
 
         elif their_choice == 'Economy':
 
@@ -408,7 +408,7 @@ class SelectMenu(ui.Select):
                     cmd_formatter.add(f"\U0000279c [`>{cmd}`](https://youtu.be/dQw4w9WgXcQ) - {cmd_details[1]}")
                     continue
 
-                command_manage = client.tree.get_app_command(cmd, guild=Object(id=interaction.guild.id))  # type: ignore
+                command_manage = client.tree.get_app_command(cmd, guild=Object(id=interaction.guild.id))  
 
                 try:
                     got_something = False
@@ -435,7 +435,7 @@ class SelectMenu(ui.Select):
                                   f'- Last modified: <t:1702722548:D> (**<t:1702722548:R>**)\n'
                                   f'- Status: **LOCKED**')
 
-            await interaction.response.edit_message(embed=embed, view=self.view)  # type: ignore
+            await interaction.response.edit_message(embed=embed, view=self.view)  
 
         else:
 
@@ -459,7 +459,7 @@ class SelectMenu(ui.Select):
                                   f' of all commands\n'
                                   f'- Last modified: <t:1703857689:D> (**<t:1703857689:R>**)\n'
                                   f'- Status: **READY**')
-            await interaction.response.edit_message(embed=embed, view=self.view)  # type: ignore
+            await interaction.response.edit_message(embed=embed, view=self.view)  
 
 
 class Select(ui.View):
@@ -470,7 +470,7 @@ class Select(ui.View):
     async def on_timeout(self) -> None:
         for item in self.children:
             item.disabled = True
-        await self.message.edit(view=self)  # type: ignore
+        await self.message.edit(view=self)  
 
 
 @client.command(name='confirm')
@@ -532,7 +532,7 @@ async def dispatch_the_webhook_when(ctx: commands.Context):
 
     embed.set_footer(icon_url=ctx.guild.icon.url, text="That's all for Q1 2024. Next review due: 30 June 2024.")
 
-    webhook = Webhook.from_url(url=client.webhook_url, session=client.session)  # type: ignore
+    webhook = Webhook.from_url(url=client.webhook_url, session=client.session)  
     thread = await ctx.guild.fetch_channel(1190736866308276394)
     rtype = "feature" or "bugfix"
     await webhook.send(f'Patch notes for Q1 2024 / This is mostly a `{rtype}` release', embed=embed,
@@ -569,7 +569,7 @@ async def help_command(interaction: Interaction):
                     inline=False)
 
     my_view = Select()
-    await interaction.response.send_message(embed=embed, view=my_view, ephemeral=True)  # type: ignore
+    await interaction.response.send_message(embed=embed, view=my_view, ephemeral=True)  
     my_view.message = await interaction.original_response()
 
 

--- a/main.py
+++ b/main.py
@@ -142,12 +142,12 @@ class MyCommandTree(app_commands.CommandTree):
                 options: List[Union[app_commands.AppCommand, app_commands.AppCommandGroup, app_commands.Argument]]):
             for option in options:
                 if isinstance(option, app_commands.AppCommandGroup):
-                    ret[option.qualified_name] = option  
-                    unpack_options(option.options)  
+                    ret[option.qualified_name] = option  # type: ignore
+                    unpack_options(option.options)  # type: ignore
 
         for command in commandsr:
             ret[command.name] = command
-            unpack_options(command.options)  
+            unpack_options(command.options)  # type: ignore
 
         return ret
 
@@ -232,6 +232,11 @@ client = C2C(command_prefix='>', intents=Intents.all(), case_insensitive=True,
 print(version)
 
 
+@client.check
+async def globally_block_dms(ctx):
+    return ctx.guild is not None
+
+
 async def load_cogs():
     for filename in listdir('./cogs'):
         if filename.endswith(".py"):
@@ -313,7 +318,7 @@ class SelectMenu(ui.Select):
                     cmd_formatter.add(f"\U0000279c [`>{cmd}`](https://youtu.be/dQw4w9WgXcQ) - {cmd_details[1]}")
                     continue
 
-                command_manage = client.tree.get_app_command(cmd, guild=Object(id=interaction.guild.id))  
+                command_manage = client.tree.get_app_command(cmd, guild=Object(id=interaction.guild.id))  # type: ignore
                 cmd_formatter.add(f"\U0000279c **{command_manage.mention}** - {cmd_details[1]}")
 
             embed.add_field(name='About: Owner',
@@ -330,13 +335,13 @@ class SelectMenu(ui.Select):
 
             embed.description = "\n".join(cmd_formatter)
 
-            await interaction.response.edit_message(embed=embed, view=self.view)  
+            await interaction.response.edit_message(embed=embed, view=self.view)  # type: ignore
 
         elif their_choice == 'Moderation':
 
             the_dict = {}
-            new_dict = return_txt_cmds_first(the_dict, their_choice)  
-            all_cmdss: dict = return_interaction_cmds_last(new_dict, their_choice)  
+            new_dict = return_txt_cmds_first(the_dict, their_choice)  # type: ignore
+            all_cmdss: dict = return_interaction_cmds_last(new_dict, their_choice)  # type: ignore
 
             embed = Embed(title='Help: Moderation', colour=Colour.from_rgb(247, 14, 115))
             embed.set_thumbnail(url='https://emoji.discadia.com/emojis/74e65408-2adb-46dc-86a7-363f3096b6b2.PNG')
@@ -356,7 +361,7 @@ class SelectMenu(ui.Select):
                                   f'- Status: **READY**')
             embed.description = "\n".join(cmd_formatter)
 
-            await interaction.response.edit_message(embed=embed, view=self.view)  
+            await interaction.response.edit_message(embed=embed, view=self.view)  # type: ignore
 
         elif their_choice == 'Utility':
 
@@ -372,7 +377,7 @@ class SelectMenu(ui.Select):
                 if cmd_details[-1] == 'txt':
                     cmd_formatter.add(f"\U0000279c [`>{cmd}`](https://youtu.be/dQw4w9WgXcQ) - {cmd_details[1]}")
                     continue
-                command_manage = client.tree.get_app_command(cmd, guild=Object(id=interaction.guild.id))  
+                command_manage = client.tree.get_app_command(cmd, guild=Object(id=interaction.guild.id))  # type: ignore
                 cmd_formatter.add(f"\U0000279c **{command_manage.mention}** - {cmd_details[1]}")
 
             embed.add_field(name='About: Utility',
@@ -386,7 +391,7 @@ class SelectMenu(ui.Select):
                                   f'- Status: **READY**')
             embed.description = "\n".join(cmd_formatter)
 
-            await interaction.response.edit_message(embed=embed, view=self.view)  
+            await interaction.response.edit_message(embed=embed, view=self.view)  # type: ignore
 
         elif their_choice == 'Economy':
 
@@ -403,7 +408,7 @@ class SelectMenu(ui.Select):
                     cmd_formatter.add(f"\U0000279c [`>{cmd}`](https://youtu.be/dQw4w9WgXcQ) - {cmd_details[1]}")
                     continue
 
-                command_manage = client.tree.get_app_command(cmd, guild=Object(id=interaction.guild.id))  
+                command_manage = client.tree.get_app_command(cmd, guild=Object(id=interaction.guild.id))  # type: ignore
 
                 try:
                     got_something = False
@@ -430,7 +435,7 @@ class SelectMenu(ui.Select):
                                   f'- Last modified: <t:1702722548:D> (**<t:1702722548:R>**)\n'
                                   f'- Status: **LOCKED**')
 
-            await interaction.response.edit_message(embed=embed, view=self.view)  
+            await interaction.response.edit_message(embed=embed, view=self.view)  # type: ignore
 
         else:
 
@@ -454,7 +459,7 @@ class SelectMenu(ui.Select):
                                   f' of all commands\n'
                                   f'- Last modified: <t:1703857689:D> (**<t:1703857689:R>**)\n'
                                   f'- Status: **READY**')
-            await interaction.response.edit_message(embed=embed, view=self.view)  
+            await interaction.response.edit_message(embed=embed, view=self.view)  # type: ignore
 
 
 class Select(ui.View):
@@ -465,7 +470,7 @@ class Select(ui.View):
     async def on_timeout(self) -> None:
         for item in self.children:
             item.disabled = True
-        await self.message.edit(view=self)  
+        await self.message.edit(view=self)  # type: ignore
 
 
 @client.command(name='confirm')
@@ -527,7 +532,7 @@ async def dispatch_the_webhook_when(ctx: commands.Context):
 
     embed.set_footer(icon_url=ctx.guild.icon.url, text="That's all for Q1 2024. Next review due: 30 June 2024.")
 
-    webhook = Webhook.from_url(url=client.webhook_url, session=client.session)  
+    webhook = Webhook.from_url(url=client.webhook_url, session=client.session)  # type: ignore
     thread = await ctx.guild.fetch_channel(1190736866308276394)
     rtype = "feature" or "bugfix"
     await webhook.send(f'Patch notes for Q1 2024 / This is mostly a `{rtype}` release', embed=embed,
@@ -564,7 +569,7 @@ async def help_command(interaction: Interaction):
                     inline=False)
 
     my_view = Select()
-    await interaction.response.send_message(embed=embed, view=my_view, ephemeral=True)  
+    await interaction.response.send_message(embed=embed, view=my_view, ephemeral=True)  # type: ignore
     my_view.message = await interaction.original_response()
 
 


### PR DESCRIPTION
This PR makes the repeat command a hybrid command, so that it can be used as both text/slash commands.
This PR also reorganizes all the imports in every file. 
Entire module imports are seperated from specific func/attr imports from a module. 