### PR TITLE
Remove the persistent colour role view

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -22,141 +22,6 @@ from cogs.economy import get_profile_key_value
 from cogs.economy import modify_profile
 
 
-class DropdownRoles(discord.ui.RoleSelect):
-    def __init__(self, colour_role_ids: set[int]):
-        self.colour_role_ids = colour_role_ids
-        super().__init__(
-            custom_id="role_select:all", 
-            placeholder="Select a colour role", 
-            row=0,
-            min_values=0)
-
-    async def callback(self, interaction: discord.Interaction) -> Any:
-
-        chosen_role = self.values
-        
-        their_roles = set(interaction.user.roles)
-        their_roles_ids = {role.id for role in their_roles}
-        common_roles = their_roles_ids.intersection(self.colour_role_ids)
-        formatted = {f"<@&{role}>" for role in common_roles}
-        
-        if not chosen_role:
-
-            if len(common_roles):
-                
-                for common_role in common_roles:
-                    await interaction.user.remove_roles(Object(id=common_role), reason="User deselected a colour role.")
-
-                return await interaction.response.send_message(
-                    embed=discord.Embed(
-                        description=f"I have removed these roles from you: {" ".join(formatted)}", 
-                        colour=0x2B2D31), 
-                    ephemeral=True, delete_after=5.0, silent=True)
-            
-            return await interaction.response.send_message(
-                "Could not find any colour roles to remove from you.", ephemeral=True, delete_after=5.0, silent=True)
-        
-        if chosen_role[0].id not in self.colour_role_ids:
-            mentionable = {f"<@&{role}>" for role in self.colour_role_ids}
-            available = discord.Embed(
-                title="Available Roles",
-                description="You did not pick a valid colour role.", 
-                colour=0x2B2D31
-            )
-            available.add_field(
-                name="You can pick these roles..",
-                value=", ".join(mentionable))
-
-            return await interaction.response.send_message(
-                embed=available, ephemeral=True, delete_after=5.0, silent=True)
-        
-        if chosen_role[0] in their_roles:
-            return await interaction.response.send_message(
-                embed=discord.Embed(
-                    colour=0x2B2D31, description="You already have that role."),
-                ephemeral=True, delete_after=5.0, silent=True)
-
-        if common_roles:
-            failure = discord.Embed(
-                title="Could not add role",
-                description=f"You already have these colour roles:\n{'\n'.join(formatted)}", 
-                colour=0x2B2D31
-            )
-            failure.set_footer(text="You'll need to remove these first.")
-
-            return await interaction.response.send_message(
-                embed=failure, ephemeral=True, delete_after=5.0, silent=True)
-
-        await interaction.user.add_roles(Object(id=chosen_role[0].id), reason="User selected a colour role.")
-        
-        success = discord.Embed(
-            title="Your Added Roles",
-            description=f"- {chosen_role[0].mention}",
-            colour=chosen_role[0].colour
-        )
-        
-        await interaction.response.send_message(embed=success, ephemeral=True, delete_after=5.0, silent=True)
-
-class PersistentView(discord.ui.View):
-    def __init__(self):
-        self.colour_role_ids = {
-            1121100838216138773, 1121100959863554048, 1121101033205149828, 1121100623853662319, 
-            1121101101807190056, 1121101829485383780, 1121100228888645753, 1121102278120710300, 
-            1121102092619239475, 1121102175037300787, 1121102453505544302, 1121102518387212449, 
-            1121102654433656832, 1121102707546148905, 1121102761635881012, 1121102853759578132, 
-            1121100064945872957, 1121103026455846973, 1121103142621290557, 1121103213790253057, 
-            1121103343343915038, 1121103457227649024, 1121103592892416101, 1121156355764535426, 
-            1121157330894069851
-        }
-        
-        super().__init__(timeout=None)
-        self.add_item(DropdownRoles(colour_role_ids=self.colour_role_ids))    
-
-
-    @discord.ui.button(label="List current colour roles", custom_id="role_view:current", row=1)
-    async def list_roles(self, interaction: discord.Interaction, button: discord.ui.Button):
-        commonplace = set(interaction.user.roles)
-        commonplace = {role.id for role in commonplace}
-        common_mention = commonplace.intersection(self.colour_role_ids)
-
-        if not common_mention:
-            return await interaction.response.send_message(
-                "You do not have any colour roles.", ephemeral=True, delete_after=5.0, silent=True)
-
-        mentionable = {f"<@&{role}>" for role in common_mention}
-        mentionable_needed = set()
-        for item in mentionable:
-            mentionable_needed.add(f"- {item}")
-
-        embed = discord.Embed(
-            title="Your current colour roles",
-            description=(f"{len(common_mention)} role found\n"
-                         "\n".join(mentionable_needed)),
-            colour=0x2B2D31
-        )
-        embed.set_footer(text="Only colour roles are listed here.")
-
-        await interaction.response.send_message(embed=embed, ephemeral=True, delete_after=5.0, silent=True)
-
-
-    @discord.ui.button(label="List available colour roles", custom_id="role_view:all", row=1)
-    async def list_available_roles(self, interaction: discord.Interaction, button: discord.ui.Button):
-        mentionable = {f"<@&{role}>" for role in self.colour_role_ids}
-        formatter = set()
-
-        for item in mentionable:
-            formatter.add(f"- {item}")
-
-        available = discord.Embed(
-            title="Available Roles",
-            description="\n".join(formatter),
-            colour=0x2B2D31
-        )
-
-        available.set_footer(text="You can select any one of these roles.")
-        await interaction.response.send_message(embed=available, ephemeral=True, silent=True)
-
-
 class Administrate(commands.Cog):
     """Cog containing commands only executable by the bot owners. Contains debugging tools."""
     def __init__(self, client: commands.Bot):
@@ -196,34 +61,6 @@ class Administrate(commands.Cog):
 
         # remove `foo`
         return content.strip('` \n')
-
-    @commands.command(name="roles", description="View and select colour roles")
-    @commands.is_owner()
-    async def colour_roles(self, ctx: commands.Context):
-        """View and select colour roles."""
-        await ctx.message.delete()
-
-        ch = self.client.get_partial_messageable(1121095327806672997)
-        msg = await self.fetch_fst_msg(ch)
-
-        colour_embed = discord.Embed(
-            title="Colour Roles",
-            colour=0xEE9FBF,
-            description=(
-                "**__IMPORTANT: PLEASE READ__**\n"
-                "- You'll need to select a colour role, so the name of the role will also be the colour.\n"
-                "- If you want to remove your current role, you must select (or deselect) the same role again.\n"
-                "- You are limited to assigning only one color role.\n"
-                "- When this bot (<@1047572530422108311>) is offline, you will not be able to select/deselect any roles.\n"
-                "- Not sure which roles you already have? Click the button below to list them.")
-        )
-
-        colour_embed.set_image(
-            url="https://i.imgur.com/BnqTZxG.jpeg")        
-
-        await ch.send(
-            content="This is where you can select a colour role to add to yourself.", 
-            embed=colour_embed, view=PersistentView(), silent=True, reference=msg.to_reference())
 
     @commands.command(name='firstmsg', description='Fetch the first message of a channel')
     async def first_message_fetchit(self, ctx: commands.Context):
@@ -897,3 +734,4 @@ class Administrate(commands.Cog):
 async def setup(client):
     """Setup for cog."""
     await client.add_cog(Administrate(client))
+    

--- a/main.py
+++ b/main.py
@@ -16,7 +16,6 @@ from typing import Dict, Optional, TYPE_CHECKING, Union, List
 from aiohttp import ClientSession
 from asqlite import create_pool
 from logging import INFO as LOGGING_INFO
-from cogs.admin import PersistentView
 
 
 if TYPE_CHECKING:
@@ -155,7 +154,6 @@ class C2C(commands.Bot):
     async def setup_hook(self):
         print("we're in.")
 
-        self.add_view(PersistentView())
         self.pool_connection = await create_pool('C:\\Users\\georg\\Documents\\c2c\\db-shit\\economy.db')
         self.time_launch = datetime.now()
 


### PR DESCRIPTION
This PR removes the colour role persistent view and its associated methods/functions/properties.

**Why have we done this?**
Well, the answer is quite simple. Onboarding was designed just for this purpose!
You can select a colour role in the main server using the 'Channels and Roles' section of the server.
It's a lot simpler and it unlike the persistent view, it actually works all the time (even when the bot is offline obviously)!

A single post-join question supports up to **50 options**, unlike the smaller **25 options** for role select menus. Clearly it seems, that it wasn't worth the upkeep and has to be removed and replaced with Discord's own feature.

Our decision is firm and we do not plan on rolling back these changes.