### PR TITLE
Rewrite the shop menu

### DIFF
--- a/other/pagination.py
+++ b/other/pagination.py
@@ -32,6 +32,7 @@ class PaginatorInput(discord.ui.Modal):
 
 
 class Pagination(discord.ui.View):
+    """Pagination menu with support for direct queries to a specific page."""
     
     def __init__(self, interaction: discord.Interaction, get_page: Callable) -> None:
         self.interaction = interaction
@@ -44,7 +45,7 @@ class Pagination(discord.ui.View):
         """Make sure only original user that invoked interaction can interact"""
         if interaction.user == self.interaction.user:
             return True
-        emb = membed("You cannot interact with this paginator")
+        emb = membed("You cannot interact with this menu")
         await interaction.response.send_message(embed=emb, ephemeral=True)
         return False
 
@@ -86,18 +87,18 @@ class Pagination(discord.ui.View):
         self.children[3].disabled = self.index == self.total_pages
         self.children[4].disabled = self.index >= self.total_pages - 1
 
-    @discord.ui.button(style=discord.ButtonStyle.blurple, emoji=discord.PartialEmoji.from_str("<:start:1212509961943252992>"))
-    async def first(self, interaction: discord.Interaction, button: discord.Button) -> None:
+    @discord.ui.button(style=discord.ButtonStyle.blurple, emoji=discord.PartialEmoji.from_str("<:start:1212509961943252992>"), row=1)
+    async def first(self, interaction: discord.Interaction, _: discord.Button) -> None:
         self.index = 1
         await self.edit_page(interaction)
 
-    @discord.ui.button(style=discord.ButtonStyle.blurple, emoji=discord.PartialEmoji.from_str("<:left:1212498142726066237>"))
-    async def previous(self, interaction: discord.Interaction, button: discord.Button) -> None:
+    @discord.ui.button(style=discord.ButtonStyle.blurple, emoji=discord.PartialEmoji.from_str("<:left:1212498142726066237>"), row=1)
+    async def previous(self, interaction: discord.Interaction, _: discord.Button) -> None:
         self.index -= 1
         await self.edit_page(interaction)
 
-    @discord.ui.button(style=discord.ButtonStyle.gray)
-    async def numeric(self, interaction: discord.Interaction, button: discord.Button) -> None:
+    @discord.ui.button(style=discord.ButtonStyle.gray, row=1)
+    async def numeric(self, interaction: discord.Interaction, _: discord.Button) -> None:
         modal = PaginatorInput(their_view=self)
         await interaction.response.send_modal(modal)
         await modal.wait()
@@ -120,14 +121,82 @@ class Pagination(discord.ui.View):
         self.index = min(self.total_pages, val) 
         await self.edit_page(interaction)
 
-    @discord.ui.button(style=discord.ButtonStyle.blurple, emoji=discord.PartialEmoji.from_str("<:right:1212498140620394548>"))
-    async def next(self, interaction: discord.Interaction, button: discord.Button) -> None:
+    @discord.ui.button(style=discord.ButtonStyle.blurple, emoji=discord.PartialEmoji.from_str("<:right:1212498140620394548>"), row=1)
+    async def next_page(self, interaction: discord.Interaction, _: discord.Button) -> None:
         self.index += 1
         await self.edit_page(interaction)
 
-    @discord.ui.button(style=discord.ButtonStyle.blurple, emoji=discord.PartialEmoji.from_str("<:final:1212509960483643392>"))
-    async def last(self, interaction: discord.Interaction, button: discord.Button) -> None:
+    @discord.ui.button(style=discord.ButtonStyle.blurple, emoji=discord.PartialEmoji.from_str("<:final:1212509960483643392>"), row=1)
+    async def last_page(self, interaction: discord.Interaction, _: discord.Button) -> None:
         self.index = self.total_pages
+        await self.edit_page(interaction)
+
+    @staticmethod
+    def compute_total_pages(total_results: int, results_per_page: int) -> int:
+        """Based off the total elements available in the iterable, determine how many pages there
+        should be within the paginator."""
+        return ((total_results - 1) // results_per_page) + 1
+
+
+class PaginationItem(discord.ui.View):
+    """Pagination menu with support for direct queries to a specific page."""
+    
+    def __init__(self, interaction: discord.Interaction, get_page: Optional[Callable] = None) -> None:
+        self.interaction = interaction
+        self.get_page = get_page
+        self.index = 1
+        self.total_pages: Optional[int] = None
+        super().__init__(timeout=45.0)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        """Make sure only original user that invoked interaction can interact"""
+        if interaction.user == self.interaction.user:
+            return True
+        emb = membed(
+            f"This shop menu is controlled by {self.interaction.user.mention}, you will have to run the original command yourself.")
+        await interaction.response.send_message(embed=emb, ephemeral=True)
+        return False
+
+    async def on_timeout(self) -> None:
+        try:
+            for item in self.children:
+                item.disabled = True
+            message = await self.interaction.original_response()
+            await message.edit(view=self)
+        except discord.NotFound:
+            pass
+
+    async def navigate(self) -> None:
+        """Get through the paginator properly."""
+        emb, self.total_pages = await self.get_page(self.index)
+        if self.total_pages == 1:
+            return await self.interaction.response.send_message(embed=emb)
+        await self.interaction.response.send_message(embed=emb, view=self)
+
+    async def edit_page(self, interaction: discord.Interaction) -> None:
+        """Update the page index in response to changes in the current page."""
+        emb, self.total_pages = await self.get_page(self.index)
+        if interaction.response.is_done():
+            message = await interaction.original_response()
+            return await interaction.followup.edit_message(
+                message_id=message.id, embed=emb, view=self)
+        await interaction.response.edit_message(embed=emb, view=self)
+
+    @discord.ui.button(style=discord.ButtonStyle.grey, emoji=discord.PartialEmoji.from_str("<:left:1212498142726066237>"), row=2)
+    async def previous(self, interaction: discord.Interaction, _: discord.Button) -> None:
+        
+        if self.index - 1 < 1:
+            self.index = self.total_pages
+        else:
+            self.index -= 1
+        await self.edit_page(interaction)
+
+    @discord.ui.button(style=discord.ButtonStyle.grey, emoji=discord.PartialEmoji.from_str("<:right:1212498140620394548>"), row=2)
+    async def next_page(self, interaction: discord.Interaction, _: discord.Button) -> None:
+        if self.index + 1 > self.total_pages:
+            self.index = 1
+        else:
+            self.index += 1
         await self.edit_page(interaction)
 
     @staticmethod


### PR DESCRIPTION
This PR adds the ability for users to purchase an item simply by clicking the item in the shop when the view it. It is more convenient and does not require the use of user input to "type in" the name of the item they want. Simply press the button, enter the quantity to purchase (in a modal), and then confirm your purchase through more buttons.

- A new pagination class was created to accomodate the new system in place
- The `/shop buy` command was removed
- There are no longer any choices that you can filter the results in the shop by. Items are now always displayed based on their cost in ascending order.
- Now, the shop command will also display your current wallet balance, though it will not update throughout the lifecycle of the view.
- The `maximum` column associated with all items was removed.